### PR TITLE
fix(test): 测试临时目录不再泄漏（#24）

### DIFF
--- a/test/claude-settings.test.ts
+++ b/test/claude-settings.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 import {
   CLAUDE_SETTINGS_PATH_ENV,
   enableCrossSessionInbound,
@@ -9,7 +12,7 @@ import {
 } from "../src/claude-settings.ts";
 
 function fixture(content?: string): { env: NodeJS.ProcessEnv; path: string; dir: string } {
-  const dir = mkdtempSync(join(tmpdir(), "ocs-settings-"));
+  const dir = tempDir("ocs-settings-");
   const path = join(dir, "settings.json");
   if (content !== undefined) writeFileSync(path, content);
   return { env: { [CLAUDE_SETTINGS_PATH_ENV]: path }, path, dir };

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -4,7 +4,6 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
   statSync,
   symlinkSync,
@@ -12,10 +11,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 
 // review #14 回归：缺值/未知 flag/多余参数必须报错退出，不许静默吞掉。
 function runCli(args: string[]): { code: number; stderr: string; stdout: string } {
-  const home = mkdtempSync(join(tmpdir(), "ocs-cli-"));
+  const home = tempDir("ocs-cli-");
   const proc = Bun.spawnSync(["bun", join(import.meta.dir, "..", "src", "cli.ts"), ...args], {
     env: { ...process.env, CODEX_HOME: join(home, "codex"), OCS_HOME: home, OCS_LANG: "en" },
   });
@@ -63,7 +65,7 @@ describe("命令级参数 schema", () => {
   });
 
   test("doctor --fix 一次修复三端 skill、Pi 扩展和数据目录权限", () => {
-    const root = mkdtempSync(join(tmpdir(), "ocs-doctor-fix-"));
+    const root = tempDir("ocs-doctor-fix-");
     const home = join(root, "home");
     const dataHome = join(root, "ocs-home");
     const piAgentDir = join(root, "pi-agent");

--- a/test/cli-e2e.test.ts
+++ b/test/cli-e2e.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CLAUDE_NATIVE_SESSIONS_DIR_ENV } from "../src/claude-inject.ts";
 import { IDLE_POLL_MS_ENV } from "../src/idle.ts";
 import { appendMessage, loadCursor, readMessages, readRoutedMessages, OCS_HOME_ENV } from "../src/store.ts";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 
 // 真 CLI 进程 + 真 UDS + 真脱离终端的 watcher。
 // 订阅方/发送方会话 = 本测试进程（CLI 的祖先，findSelfClaudePid 命中，名 tester）；
@@ -29,7 +32,7 @@ interface Fixture {
 }
 
 function fixture(options: { withSelf?: boolean; selfCwd?: string; peerCwd?: string } = {}): Fixture {
-  const dir = mkdtempSync(join(tmpdir(), "ocs-e2e-"));
+  const dir = tempDir("ocs-e2e-");
   const sessionsDir = join(dir, "sessions");
   mkdirSync(sessionsDir, { mode: 0o700 });
   const sockPath = join(dir, "inbox.sock");

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { codexSessionsRoot, listCodexSessions } from "../src/codex-sessions.ts";
 import { discoverCodexDesktopOwners } from "../src/codex-ipc.ts";
 import { pickCodexSourceThread, splitWakeMentions, wakeCodexTask } from "../src/wake.ts";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 
 const THREAD_A = "aaaaaaaa-1111-2222-3333-444444444444";
 const THREAD_B = "bbbbbbbb-1111-2222-3333-444444444444";
@@ -13,7 +16,7 @@ const THREAD_C = "cccccccc-1111-2222-3333-444444444444";
 const CLI = join(import.meta.dir, "..", "src", "cli.ts");
 
 function rolloutFixture(options: { withThreadC?: boolean } = {}): NodeJS.ProcessEnv {
-  const codexHome = mkdtempSync(join(tmpdir(), "ocs-codex-"));
+  const codexHome = tempDir("ocs-codex-");
   const day = join(codexHome, "sessions", "2026", "08", "31");
   mkdirSync(day, { recursive: true });
   const meta = (cwd: string) =>
@@ -41,7 +44,7 @@ describe("codex-sessions（rollout 发现）", () => {
     const env = rolloutFixture();
     expect(pickCodexSourceThread(THREAD_B, env)).toBe(THREAD_A);
     expect(pickCodexSourceThread(THREAD_A, env)).toBe(THREAD_B);
-    expect(pickCodexSourceThread(THREAD_A, { CODEX_HOME: mkdtempSync(join(tmpdir(), "ocs-empty-")) })).toBeNull();
+    expect(pickCodexSourceThread(THREAD_A, { CODEX_HOME: tempDir("ocs-empty-") })).toBeNull();
   });
 });
 
@@ -128,7 +131,7 @@ async function runCli(
   const env = {
     ...process.env,
     ...router.env,
-    OCS_HOME: mkdtempSync(join(tmpdir(), "ocs-codex-cli-")),
+    OCS_HOME: tempDir("ocs-codex-cli-"),
     OCS_LANG: "en",
     ...extraEnv,
   } as Record<string, string>;
@@ -341,7 +344,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
       body: "hello codex",
       seq: 1,
       from: "a",
-      env: { CODEX_HOME: mkdtempSync(join(tmpdir(), "ocs-noipc-")) },
+      env: { CODEX_HOME: tempDir("ocs-noipc-") },
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("unavailable");

--- a/test/idle.test.ts
+++ b/test/idle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -15,6 +15,9 @@ import {
   saveIdleSubscription,
 } from "../src/idle.ts";
 import { OCS_HOME_ENV } from "../src/store.ts";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 
 // 订阅方 = 本测试进程（有真 socket 收帧）；目标 = 每个 fixture 自己的 sleep 子进程
 // （活 pid，可随时杀）。不用 beforeAll 共享：bun test 在用例超时后会杀掉所有子进程。
@@ -32,7 +35,7 @@ interface Fixture {
 }
 
 function fixture(): Fixture {
-  const dir = mkdtempSync(join(tmpdir(), "ocs-idle-"));
+  const dir = tempDir("ocs-idle-");
   const sessionsDir = join(dir, "sessions");
   mkdirSync(sessionsDir, { mode: 0o700 });
   const sockPath = join(dir, "sub.sock");

--- a/test/inbox.test.ts
+++ b/test/inbox.test.ts
@@ -9,13 +9,16 @@ import {
   type InboxIdentityContext,
 } from "../src/inbox.ts";
 import { appendMessage, readRoutedMessages, saveCursor } from "../src/store.ts";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 
 const ALICE = `workspace:${"a".repeat(64)}`;
 const BOB = `workspace:${"b".repeat(64)}`;
 const MALLORY = `workspace:${"c".repeat(64)}`;
 
 function fixture(): { env: NodeJS.ProcessEnv; bob: InboxIdentityContext } {
-  const home = mkdtempSync(join(tmpdir(), "ocs-inbox-"));
+  const home = tempDir("ocs-inbox-");
   return {
     env: { OCS_HOME: home },
     bob: {

--- a/test/roster.test.ts
+++ b/test/roster.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CLAUDE_NATIVE_SESSIONS_DIR_ENV } from "../src/claude-inject.ts";
@@ -18,11 +18,14 @@ import {
 import { resetClaudeAddressCachesForTest } from "../src/claude-address.ts";
 import { verifiedClaudeWorkspaceIdentity } from "../src/workspace-registry.ts";
 import { appendMessage, loadCursor, readMessages, saveCursor, OCS_HOME_ENV } from "../src/store.ts";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 
 const THREAD = "aaaaaaaa-1111-2222-3333-444444444444";
 
 function sessionsFixture(options: { name?: string; cwd?: string } = {}): NodeJS.ProcessEnv {
-  const dir = mkdtempSync(join(tmpdir(), "ocs-roster-"));
+  const dir = tempDir("ocs-roster-");
   const sessionsDir = join(dir, "sessions");
   mkdirSync(sessionsDir, { mode: 0o700 });
   writeFileSync(
@@ -128,7 +131,7 @@ describe("resolveDmTarget", () => {
   });
 
   test("同一工作区多个活会话时别名判歧义，不任选目标", () => {
-    const dir = mkdtempSync(join(tmpdir(), "ocs-roster-ambiguous-"));
+    const dir = tempDir("ocs-roster-ambiguous-");
     const sessionsDir = join(dir, "sessions");
     mkdirSync(sessionsDir, { mode: 0o700 });
     const peer = Bun.spawn(["sleep", "30"], { stdio: ["ignore", "ignore", "ignore"] });
@@ -200,7 +203,7 @@ test("工作区别名与另一活会话的精确名冲突时不得用于短 Repl
 });
 
 test("稳定工作区身份跨会话名不变，同 basename 不同绝对路径不碰撞", () => {
-  const env = { [OCS_HOME_ENV]: mkdtempSync(join(tmpdir(), "ocs-identity-")) };
+  const env = { [OCS_HOME_ENV]: tempDir("ocs-identity-") };
   const base = {
     pid: 101,
     sessionId: "old",
@@ -224,7 +227,7 @@ test("稳定工作区身份跨会话名不变，同 basename 不同绝对路径�
 });
 
 test("HTTPS / SSH 形式的同一 Git 远程得到同一工作区身份", () => {
-  const root = mkdtempSync(join(tmpdir(), "ocs-git-anchor-"));
+  const root = tempDir("ocs-git-anchor-");
   const first = join(root, "first");
   const second = join(root, "second");
   mkdirSync(first);
@@ -257,7 +260,7 @@ test("HTTPS / SSH 形式的同一 Git 远程得到同一工作区身份", () => 
 });
 
 test("workspace-key 丢失时拒绝生成新身份，不静默漂移频道", () => {
-  const home = mkdtempSync(join(tmpdir(), "ocs-key-loss-"));
+  const home = tempDir("ocs-key-loss-");
   const env = { [OCS_HOME_ENV]: home };
   const session = {
     pid: 101,
@@ -289,7 +292,7 @@ test("workspace-key 丢失时目标仍可按精确会话名解析，只禁用稳
 });
 
 test("同一别名的持久身份发生变化时禁用稳定频道并给出诊断", () => {
-  const root = mkdtempSync(join(tmpdir(), "ocs-identity-conflict-"));
+  const root = tempDir("ocs-identity-conflict-");
   const env = { [OCS_HOME_ENV]: join(root, "home") };
   const first = {
     pid: 101,
@@ -311,7 +314,7 @@ test("同一别名的持久身份发生变化时禁用稳定频道并给出诊�
 
 describe("findDmReplyChannel（跨载体反向 dm 会话收敛，review 回归）", () => {
   test("被唤醒方读过的频道里有对方发言 → 反向 dm 续用同一频道", () => {
-    const env = { [OCS_HOME_ENV]: require("node:fs").mkdtempSync(require("node:path").join(require("node:os").tmpdir(), "ocs-dmrev-")) };
+    const env = { [OCS_HOME_ENV]: tempDir("ocs-dmrev-") };
     // 正向：alice dm 一个 codex 目标 → 频道按载体身份派生
     const target = resolveDmTarget("aaaaaaaa-1111-2222-3333-444444444444", env)!;
     const forward = dmChannel(selfIdentity("alice"), target.identity);
@@ -351,7 +354,7 @@ describe("resolveSelfName", () => {
 });
 
 test("codex-<8hex> 短地址解析到唯一的本地 thread id", () => {
-  const root = mkdtempSync(join(tmpdir(), "ocs-codex-short-"));
+  const root = tempDir("ocs-codex-short-");
   const day = join(root, "sessions", "2026", "09", "04");
   mkdirSync(day, { recursive: true });
   writeFileSync(

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, unlinkSync } from "node:fs";
+import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 import {
   appendDmMessage,
   appendMessage,
@@ -16,7 +19,7 @@ import {
 } from "../src/store.ts";
 
 function freshEnv(): NodeJS.ProcessEnv {
-  return { [OCS_HOME_ENV]: mkdtempSync(join(tmpdir(), "ocs-store-")) };
+  return { [OCS_HOME_ENV]: tempDir("ocs-store-") };
 }
 
 describe("stable DM channel bindings (#10)", () => {

--- a/test/tmp.test.ts
+++ b/test/tmp.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { cleanupTempDirs, tempDir } from "./tmp";
+
+afterEach(() => cleanupTempDirs());
+
+describe("temporary test directory cleanup", () => {
+  test("removes every registered directory", () => {
+    const first = tempDir("ocs-tmp-helper-");
+    const second = tempDir("ocs-tmp-helper-");
+
+    cleanupTempDirs();
+
+    expect(existsSync(first)).toBe(false);
+    expect(existsSync(second)).toBe(false);
+  });
+
+  test("reports failures and keeps their paths for a later retry", () => {
+    const dir = tempDir("ocs-tmp-helper-");
+
+    expect(() => cleanupTempDirs(() => {
+      throw new Error("busy");
+    })).toThrow(`failed to clean 1 temporary test directory: ${dir}`);
+    expect(existsSync(dir)).toBe(true);
+
+    cleanupTempDirs();
+    expect(existsSync(dir)).toBe(false);
+  });
+});

--- a/test/tmp.ts
+++ b/test/tmp.ts
@@ -20,15 +20,30 @@ export function tempDir(prefix: string): string {
   return dir;
 }
 
-/** 立即清掉已登记的目录；afterEach 会自动调用，一般不用手动调。 */
-export function cleanupTempDirs(): void {
+type RemoveTempDir = (dir: string) => void;
+
+function removeTempDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** 立即清掉已登记的目录；失败项保留到下一次清理重试，并在本轮统一报错。 */
+export function cleanupTempDirs(remove: RemoveTempDir = removeTempDir): void {
+  const failures: Array<{ dir: string; error: unknown }> = [];
   for (const dir of created.splice(0)) {
-    // 清理失败不能弄挂测试：临时目录删不掉只是留垃圾，不是被测行为出错。
     try {
-      rmSync(dir, { recursive: true, force: true });
-    } catch {
-      // 忽略
+      remove(dir);
+    } catch (error) {
+      created.push(dir);
+      failures.push({ dir, error });
     }
+  }
+
+  if (failures.length > 0) {
+    const paths = failures.map(({ dir }) => dir).join(", ");
+    throw new AggregateError(
+      failures.map(({ error }) => error),
+      `failed to clean ${failures.length} temporary test director${failures.length === 1 ? "y" : "ies"}: ${paths}`,
+    );
   }
 }
 
@@ -39,5 +54,5 @@ import { afterEach } from "bun:test";
 
 /** 在调用方文件里注册「每个用例后清掉本文件建的临时目录」。 */
 export function autoCleanupTempDirs(): void {
-  afterEach(cleanupTempDirs);
+  afterEach(() => cleanupTempDirs());
 }

--- a/test/tmp.ts
+++ b/test/tmp.ts
@@ -1,0 +1,43 @@
+// 测试用临时目录的统一创建与清理（#24）。
+//
+// 此前各测试各自 mkdtempSync，但只有 pi/install/pi-cli 三个文件做了清理，其余建完就不管。
+// 单个目录不大，CI 与本地反复跑之后按千计累积——2026-09-04 这台机器 $TMPDIR 里躺着
+// 3150 个 ocs-* 目录，和别的残留一起把磁盘撑到 100%，`ENOSPC` 让 party join、codex runner
+// 甚至 shell 钩子全线报错。
+//
+// 用法：把 `mkdtempSync(join(tmpdir(), "ocs-x-"))` 换成 `tempDir("ocs-x-")`。
+// 用法：import { tempDir, autoCleanupTempDirs } from "./tmp"; 顶层调用一次 autoCleanupTempDirs()。
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const created: string[] = [];
+
+/** 建一个测试用临时目录，登记后在本用例结束时自动删除。 */
+export function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  created.push(dir);
+  return dir;
+}
+
+/** 立即清掉已登记的目录；afterEach 会自动调用，一般不用手动调。 */
+export function cleanupTempDirs(): void {
+  for (const dir of created.splice(0)) {
+    // 清理失败不能弄挂测试：临时目录删不掉只是留垃圾，不是被测行为出错。
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // 忽略
+    }
+  }
+}
+
+// 清理必须由测试文件自己挂：afterEach/afterAll 只作用于调用它的那个文件的套件，
+// 在这个被 import 的帮助模块里调用不生效；process.on("exit") 在 bun test 下也不触发
+// （两种都实测过，残留照涨）。所以导出一个注册函数，测试文件顶层调用一次即可。
+import { afterEach } from "bun:test";
+
+/** 在调用方文件里注册「每个用例后清掉本文件建的临时目录」。 */
+export function autoCleanupTempDirs(): void {
+  afterEach(cleanupTempDirs);
+}

--- a/test/wake.test.ts
+++ b/test/wake.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
 import {
   CLAUDE_NATIVE_SESSIONS_DIR_ENV,
   injectChannelMessage,
@@ -32,7 +35,7 @@ interface Fixture {
 }
 
 function fixture(options: { pid?: number; name?: string; sessionId?: string; sockName?: string; cwd?: string } = {}): Fixture {
-  const dir = mkdtempSync(join(tmpdir(), "ocs-wake-"));
+  const dir = tempDir("ocs-wake-");
   const sessionsDir = join(dir, "sessions");
   mkdirSync(sessionsDir, { mode: 0o700 });
   const sockPath = join(dir, options.sockName ?? "inbox.sock");
@@ -294,7 +297,7 @@ describe("findSelfClaudePid：ps 缺失也不许炸", () => {
   // 祖先链用真子进程验证：测试进程自己写 sessions json，子进程（CLI）沿祖先链找到它。
   // 不拿 process.ppid 当断言依据——容器里 bun test 的父进程就是 pid 1。
   function whoami(pathEnv: string | undefined): { code: number | null; stdout: string; stderr: string } {
-    const dir = mkdtempSync(join(tmpdir(), "ocs-self-"));
+    const dir = tempDir("ocs-self-");
     const sessionsDir = join(dir, "sessions");
     mkdirSync(sessionsDir, { mode: 0o700 });
     writeFileSync(
@@ -324,7 +327,7 @@ describe("findSelfClaudePid：ps 缺失也不许炸", () => {
   }, 30_000);
 
   test("PATH 指向空目录（无 ps）：不崩——有 /proc 的 Linux 照样认出，否则明确说认不出", () => {
-    const r = whoami(mkdtempSync(join(tmpdir(), "ocs-empty-bin-")));
+    const r = whoami(tempDir("ocs-empty-bin-"));
     expect(r.stderr).not.toContain("TypeError");
     if (existsSync("/proc/self/stat")) {
       expect(r.code).toBe(0);


### PR DESCRIPTION
Closes #24

## 问题
测试用 `mkdtempSync` 建临时目录，但全仓只有 `pi` / `install` / `pi-cli` 三个文件清理，其余建完不管。单个不大，反复跑之后按千计累积——这台开发机 `$TMPDIR` 里躺着 **3150 个 `ocs-*`**，和别的残留一起把磁盘撑到 100%，`ENOSPC` 让 `party join`、codex runner、甚至 shell 钩子全线报错。

## 改动
- 新增 `test/tmp.ts`：`tempDir(prefix)` 建目录并登记；`autoCleanupTempDirs()` 由各测试文件顶层调一次，挂 `afterEach` 逐用例清理。
- 9 个测试文件改用它（含一处内联 `require("node:fs").mkdtempSync(...)` 的写法，正则容易漏）。
- 清掉随之不再使用的 `mkdtempSync` import。

## 两条走不通的路（都实测过，写进注释免得后人再踩）
1. **在 `tmp.ts` 顶层调 `afterEach`**：只作用于调用它的那个文件的套件，帮助模块里调等于没挂 —— 残留照涨。
2. **`process.on("exit")`**：bun test 下根本不触发。我写了个探针用例（建目录 → 断言进程退出后是否还在）才确认。

所以清理必须由每个测试文件自己注册，这也是 `autoCleanupTempDirs()` 存在的理由。

## 验证
| | 残留净增 |
|---|---|
| 改动前 | +98 ～ +183 / 轮 |
| 改动后 | **0** |

- `bunx tsc --noEmit` 0 错
- `bun run check`：129 pass / 1 fail，与**未改动 main 的基线完全一致**（`resolveSelfName > Codex 会话直接使用宿主提供的 thread id` 在原始 main 上同样红，环境依赖，会读到本机真实会话名，与本 PR 无关）

## 建议后续（未做）
加一条守卫测试：测试文件里出现 `mkdtempSync` 就必须出现 `autoCleanupTempDirs`，防止新增用例又漏。

https://claude.ai/code/session_01HUmERHTXnbZhCZCwV6fGxD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Centralized temporary-directory creation across the test suite.
  * Added automatic cleanup of temporary test directories after each test.
  * Preserved existing test scenarios and assertions while reducing leftover temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->