### PR TITLE
fix: 明确区分消息落盘与唤醒结果（v0.4.2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.4.2
+
+- 发送输出明确区分 `stored` 与 wake 结果；唤醒失败返回退出码 2、结果未知返回退出码 3，并提醒消息已落盘、不可重发
+- `send --codex` 与 `--codex-source` 直接接受 `ocs who` 展示的 `codex-<8hex>` 短地址；无效或歧义地址在消息落盘前失败
+- CLI help、README 与安装 skill 补齐 ChatGPT Desktop 的第二个同 renderer source task 前置条件
+- 明确跨机器边界：托管协作用 Agent Party；已有免密 SSH 时由控制端直接调用 workbox 上的本地 OCS/Herdr，不在 OCS 增加远程 runtime
+- 测试临时目录统一按用例清理，删除失败会保留路径重试并使测试可见地失败；全量测试不再净增 `ocs-*` 残留
+
 ## v0.4.1
 
 - Codex roster 只展示被 ChatGPT Desktop renderer 实际认领的 open task，不再把本地 rollout 历史误报成可达

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ The protocol is shared with Agent Party: [docs/wake-protocol.md](./docs/wake-pro
 | Target | How | Requirement |
 |---|---|---|
 | Interactive Claude Code session | `@<session name>` | Receiver sets `"crossSessionInbound": "accept"` in `~/.claude/settings.json`. The default is `hold`: the message waits for manual approval and is **silently dropped after 5 minutes**. `ocs doctor` checks this. |
-| ChatGPT Desktop task | `ocs dm codex-<8hex> …`, `@<thread-id>`, or `--codex <thread-id>` | The task must be open in the ChatGPT **Desktop app**, with a second open task under the same renderer as the message source (auto-picked, or `--codex-source`). |
+| ChatGPT Desktop task | `ocs dm codex-<8hex> …`, `@<thread-id>`, or `--codex <thread-id\|codex-8hex>` | The task must be open in the ChatGPT **Desktop app**, with a second open task under the same renderer as the message source (auto-picked, or `--codex-source`). |
 | Pi TUI | `ocs dm pi-<8hex> …` or `@pi-<full-session-id>` | Run `ocs skill install`, then restart Pi. The installed extension registers the live TUI and queues inbound messages as follow-ups, so a busy turn is not interrupted. |
 | Claude/Codex terminal TUI in cmux | `ocs dm surface:<n> …` | Optional: when cmux is detected, `ocs who` lists terminal surfaces and can submit the wake note to an idle surface. A busy surface is left untouched. |
 | Other terminal or headless agent | `ocs read` / `ocs send` | Full channel participation, persistence, and replies, but no unsolicited direct wake unless its harness exposes a supported carrier. |
 | Human at a shell | `ocs send` / `ocs read` / `ocs watch` | Can post, read once, or tail the same channels without running an agent. |
 
-Delivery honesty: for Claude targets, a successful send means the frame reached the target's inbox socket — with `accept` it enters the conversation; with `hold` it may still be dropped. Pi success means its extension accepted and queued the message. For Desktop and Pi, an unknown outcome after writing a frame is reported and **never retried**, avoiding double delivery.
+Delivery honesty: the first line says `stored #<channel> seq <n>` once the append-only log commit succeeds; it does not claim wake delivery. Each requested wake then reports accepted, stored-only, or unknown separately. Exit 2 means the message is stored but at least one wake failed; exit 3 means the message is stored and a wake outcome is unknown. In either case, do **not** resend: use the printed channel and seq to inspect the existing message. For Claude targets, accepted means the frame reached the target's inbox socket — with `accept` it enters the conversation; with `hold` it may still be dropped. Pi acceptance means its extension queued the message.
 
 For Codex, `ocs who` includes only tasks currently claimed by an open Desktop
 renderer. `ocs codex-sessions` is rollout history, not presence. A DM to a task
@@ -125,7 +125,7 @@ the target can recover it with `ocs inbox`, but it is not described as woken.
 | `ocs whoami` | Print the auto-detected sender identity |
 | `ocs dm <name-or-id> <text>` | Message + wake one agent; unique Claude workspaces keep one channel across restarts. `--inherit <old-dm-channel>` binds pre-v0.3.4 history once; `--notify-when-idle` |
 | `ocs inbox` | List unread threads that can be safely attributed to the current identity; `--json` for automation |
-| `ocs send <ch> <body>` | Append to a channel; `@` mentions wake, `--reply-to <seq>` also wakes that seq's author. `--as` is only an override. Also supports `--no-wake`, `--notify-when-idle`, `--codex`, `--codex-source` |
+| `ocs send <ch> <body>` | Append to a channel; `@` mentions wake, `--reply-to <seq>` also wakes that seq's author. `--as` is only an override. `--codex` and `--codex-source` accept a full thread ID or the unambiguous `codex-<8hex>` printed by `ocs who`. Also supports `--no-wake` and `--notify-when-idle` |
 | `ocs read <ch>` | Read new messages since your cursor, then advance it. Your own messages fold to one line (`--include-self` shows them; `--json` adds `self`). `--as` overrides identity; also supports `--since`, `--peek` |
 | `ocs notify-when-idle <name>` | One-shot: a `[Cross-session idle notice]` lands in your session when that Claude session next goes idle or exits (immediately if already idle; expires after 6h) |
 | `ocs sessions` | List live Claude Code sessions |
@@ -184,6 +184,27 @@ Honest guidance: for a quick claude↔claude direct message, native is smoother 
 ocs's Claude carrier literally rides on the native inbox socket. Use ocs when the
 conversation crosses vendors, needs more than two participants, needs messages to
 survive one side being offline, or should leave an auditable trail.
+
+## Cross-machine: keep OCS local
+
+OCS deliberately has no public listener, remote shell, credential store, or job
+runner. For hosted cross-machine coordination, use Agent Party. When two personal
+machines already have passwordless SSH, keep authentication and host-key checking
+in the user's SSH config and invoke the target machine's local tools directly:
+
+```bash
+ssh workbox ocs who --verbose
+ssh workbox ocs dm codex-<8hex> "review the current failure"
+
+# Remote agent/runtime control remains Herdr's job, not OCS's.
+ssh workbox herdr agent list
+ssh workbox herdr agent prompt reviewer "run tests and summarize failures" --wait --timeout 120000
+```
+
+The SSH direction determines the roles. If only machine B can connect to machine
+A, then B is the controller and A is `workbox`; no reverse login or OCS adapter is
+needed. Prefix remote targets with the SSH host in human-facing instructions (for
+example `workbox/reviewer`) so they cannot be confused with same-named local agents.
 
 ## Local vs hosted
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,13 +97,13 @@ Claude→Claude DM 的「回复」行优先使用发送方的唯一工作区别�
 | 目标 | 用法 | 前提 |
 |---|---|---|
 | 交互式 Claude Code 会话 | `@<会话名>` | 接收端在 `~/.claude/settings.json` 设 `"crossSessionInbound": "accept"`。默认值 `hold`：消息进待审队列，**5 分钟没人处理就被静默丢弃**。`ocs doctor` 会查这一项。 |
-| ChatGPT Desktop 任务 | `ocs dm codex-<8hex> …`、`@<thread-id>` 或 `--codex <thread-id>` | 任务要在 ChatGPT **Desktop 应用**里开着，且同一 renderer 下还有第二个打开的任务作消息来源（自动挑选，或 `--codex-source` 指定）。 |
+| ChatGPT Desktop 任务 | `ocs dm codex-<8hex> …`、`@<thread-id>` 或 `--codex <thread-id\|codex-8hex>` | 任务要在 ChatGPT **Desktop 应用**里开着，且同一 renderer 下还有第二个打开的任务作消息来源（自动挑选，或 `--codex-source` 指定）。 |
 | Pi TUI | `ocs dm pi-<8hex> …` 或 `@pi-<完整session-id>` | 先跑 `ocs skill install`，再重启 Pi。扩展会登记活着的 TUI；消息在 Pi 忙碌时排到当前任务结束后，不会打断这一轮。 |
 | cmux 里的 Claude/Codex TUI | `ocs dm surface:<n> …` | 可选能力。检测到 cmux 后，`ocs who` 会列出终端 surface，并可把唤醒 note 提交给空闲 surface；surface 忙碌时不会打扰。 |
 | 其他终端或 headless agent | `ocs read` / `ocs send` | 可以读写频道、保留历史和回复；如果所在 harness 没有受支持的载体，就不能被主动直投唤醒。 |
 | shell 前的人 | `ocs send` / `ocs read` / `ocs watch` | 不运行 agent 也能发消息、读取一次或持续旁观同一频道。 |
 
-送达语义按载体区分：Claude 目标发送成功，只代表帧到了对方收件箱 socket；`accept` 下进入对话，`hold` 下仍可能被丢。Pi 成功表示扩展已接收并排队。Desktop 或 Pi 的帧写出后若没收到响应，`ocs` 会报「结果未知」且不重发，避免重复投递。
+投递语义分两层：首行 `已落盘 #<channel> seq <n>` 只表示 append-only 日志提交成功，不代表已经唤醒。随后每个 wake 请求分别报告已接受、仅落盘或结果未知。退出码 2 表示消息已落盘但至少一次唤醒失败；退出码 3 表示已落盘且唤醒结果未知。两种情况都不要重发，应使用输出里的 channel/seq 查原消息。Claude 的“已投递收件箱”只代表帧到了 socket；`accept` 下进入对话，`hold` 下仍可能被丢。Pi 的“已排队”表示扩展已接收。
 
 Codex 侧，`ocs who` 只列当前被打开的 Desktop renderer 认领的 task；`ocs codex-sessions`
 只是 rollout 历史，不是在线状态。发给已关闭 task 的 DM 仍会写入 append-only 日志并明确标为停靠，
@@ -117,7 +117,7 @@ Codex 侧，`ocs who` 只列当前被打开的 Desktop renderer 认领的 task�
 | `ocs whoami` | 看自动识别出的发送者身份 |
 | `ocs dm <名字或id> <内容>` | 直发并唤醒一个 agent；唯一 Claude 工作区重启后继续使用同一频道。`--inherit <旧dm频道>` 一次性绑定 v0.3.4 前的历史；`--notify-when-idle` |
 | `ocs inbox` | 只列能安全归属给当前身份的未读线程；`--json` 供自动化使用 |
-| `ocs send <ch> <body>` | 追加消息，`@` 触发唤醒，`--reply-to <seq>` 同时唤醒那条的作者；`--as` 只用于覆盖自动身份。另支持 `--no-wake`、`--notify-when-idle`、`--codex`、`--codex-source` |
+| `ocs send <ch> <body>` | 追加消息，`@` 触发唤醒，`--reply-to <seq>` 同时唤醒那条的作者；`--as` 只用于覆盖自动身份。`--codex` 与 `--codex-source` 接受完整 thread ID，也接受 `ocs who` 给出的唯一 `codex-<8hex>` 短地址。另支持 `--no-wake`、`--notify-when-idle` |
 | `ocs read <ch>` | 从游标读新消息并推进。自己发的折叠成一行（`--include-self` 完整显示；`--json` 带 `self`）；`--as` 覆盖身份。另支持 `--since`、`--peek` |
 | `ocs notify-when-idle <名字>` | 一次性：那个 Claude 会话下次空闲或退出时，你的会话收到一条 `[跨会话空闲通知]`（已空闲则立即；6 小时后过期） |
 | `ocs sessions` | 列活着的 Claude Code 会话 |
@@ -164,6 +164,21 @@ v0.3.4 之前的历史可用 `--inherit` 绑定一次；工作区不唯一、旧
 诚实建议：claude↔claude 的快速直发用原生更顺——ocs 的 Claude 载体本来就骑在
 原生收件箱 socket 上。当对话跨厂商、超过两方、需要消息在一边离线时不丢、或要留
 可审计记录时，用 ocs。
+
+## 跨机器：保持 OCS 本地化
+
+OCS 刻意不提供公网监听、远程 shell、凭据存储或通用任务执行器。需要托管的跨机器协作时用 Agent Party。两台个人机器已有免密 SSH 时，继续由用户的 SSH config 负责认证与 host key 校验，控制端直接调用目标机器上的本地工具：
+
+```bash
+ssh workbox ocs who --verbose
+ssh workbox ocs dm codex-<8hex> "检查当前失败"
+
+# 远端 agent/runtime 管理属于 Herdr，不在 OCS 重造。
+ssh workbox herdr agent list
+ssh workbox herdr agent prompt reviewer "跑测试并总结失败" --wait --timeout 120000
+```
+
+SSH 免密方向决定角色。如果只有机器 B 能连接机器 A，那么 B 就是控制端，A 就是 `workbox`；不需要反向登录或新增 OCS adapter。面向人的指令应给远端 agent 带上 SSH 主机命名空间（例如 `workbox/reviewer`），避免与本机同名 agent 混淆。
 
 ## 本地版与托管版
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-cross-session",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "跨 agent 的 cross-session，本机直连，零服务器 — local-first personal agent party",
   "license": "MIT",
   "type": "module",

--- a/skills/ocs/SKILL.md
+++ b/skills/ocs/SKILL.md
@@ -16,6 +16,7 @@ ocs dm <name> "<text>" --inherit <old-dm-channel>  # one-time history binding
 ocs inbox                        # unread threads attributable to this identity
 ocs send <channel> "<text>"      # post into a channel; @<name> wakes that agent
 ocs send <channel> "<text>" --reply-to <seq>   # reply; also wakes the author of <seq>
+ocs send <channel> "<text>" --codex codex-<8hex>  # short ID from ocs who also works
 ocs read <channel>               # read new messages (your own fold to one line;
                                  # --include-self shows them; --json adds self:bool)
 ocs notify-when-idle <name>      # one-shot: notice here when <name> next goes idle/exits
@@ -28,6 +29,8 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
   use the full ID shown by `ocs who --verbose` only if a short prefix is ambiguous.
 - `ocs who` lists only Codex tasks claimed by an open Desktop renderer.
   `ocs codex-sessions` is rollout history and does not imply wakeability.
+  Codex wake also needs a second open task under the same Desktop renderer as
+  the source; `--codex-source` accepts either its full ID or short address.
 - A wake note you receive carries the message body (up to 4096 bytes; longer
   messages show the first 512 bytes plus a Thread: command). Claude-to-Claude DM
   replies use the short `ocs dm <workspace-alias>` form when that alias identifies
@@ -44,7 +47,10 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
   `--notify-when-idle` on send/dm). You get exactly one
   `[Cross-session idle notice]` when it goes idle or exits (immediately if it is
   already idle; expires after 6h). No polling, no "done yet?" messages.
-- Delivery honesty: "delivered to inbox" or "queued" does not mean the model read it.
+- Delivery honesty: `stored #<channel> seq <n>` means only that the append-only
+  log commit succeeded. Requested wakes report accepted, stored-only, or unknown
+  separately. Exit 2 means stored but wake failed; exit 3 means stored with an
+  unknown outcome. Never resend either result; inspect the printed channel/seq.
 - If a Codex task is not renderer-open, the message remains stored and will appear
   in that task's `ocs inbox`; opening/selecting its Desktop task enables direct wake.
 - To keep a conversation going, end your message with the peer's @name so they wake

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,7 @@ import {
   wakeSessions,
 } from "./wake.ts";
 
-export const OCS_VERSION = "0.4.1";
+export const OCS_VERSION = "0.4.2";
 
 const LANG = detectLang();
 const M = messages(LANG);
@@ -193,6 +193,31 @@ function fail(message: string): never {
   process.exit(1);
 }
 
+type StoredDeliveryFailure = "failed" | "unknown";
+
+/**
+ * The channel append is already committed when wake delivery runs. Preserve
+ * that distinction in the process status so automation can stop without
+ * retrying the stored message.
+ */
+function markStoredDeliveryFailure(outcome: StoredDeliveryFailure): void {
+  const code = outcome === "unknown" ? 3 : 2;
+  process.exitCode = Math.max(Number(process.exitCode ?? 0), code);
+}
+
+/** Resolve the full UUID or the exact short address printed by `ocs who`. */
+function resolveCodexFlagAddress(flag: "codex" | "codex-source", value: string): string {
+  if (isCodexThreadId(value)) return value.toLowerCase();
+  const resolved = resolveDmTarget(value);
+  if (resolved?.ambiguousCodexTargets !== undefined) {
+    fail(M.dmCodexAmbiguous(value, resolved.ambiguousCodexTargets));
+  }
+  if (resolved?.kind === "codex-task" && resolved.threadId !== undefined) {
+    return resolved.threadId;
+  }
+  fail(M.failCodexAddress(flag, value));
+}
+
 function printMessage(m: { seq: number; ts: string; from: string; body: string }): void {
   console.log(`#${m.seq} ${m.ts} <${m.from}> ${m.body}`);
 }
@@ -235,6 +260,16 @@ async function cmdSend(parsed: Parsed): Promise<void> {
   const [channel, ...bodyParts] = parsed.positional;
   if (channel === undefined || bodyParts.length === 0) fail(M.failSendUsage);
   const from = senderName(parsed);
+  // Address syntax/ambiguity is validated before append: malformed flags must
+  // never create a message that could not possibly be delivered.
+  const codexFlagValue = parsed.flags.get("codex");
+  const codexFlag = typeof codexFlagValue === "string"
+    ? resolveCodexFlagAddress("codex", codexFlagValue)
+    : undefined;
+  const codexSourceValue = parsed.flags.get("codex-source");
+  const codexSource = typeof codexSourceValue === "string"
+    ? resolveCodexFlagAddress("codex-source", codexSourceValue)
+    : undefined;
   const replyTo = parsed.flags.get("reply-to");
   let replyToSeq: number | undefined;
   if (replyTo !== undefined) {
@@ -263,7 +298,7 @@ async function cmdSend(parsed: Parsed): Promise<void> {
     body: bodyParts.join(" "),
     ...(replyToSeq !== undefined ? { reply_to: replyToSeq } : {}),
   });
-  console.log(M.sent(channel, message.seq));
+  console.log(M.stored(channel, message.seq));
 
   if (parsed.flags.has("no-wake")) return;
 
@@ -278,12 +313,10 @@ async function cmdSend(parsed: Parsed): Promise<void> {
   const { claudeNames, codexThreads, piTargets } = splitWakeMentions(wakeAddresses);
 
   // Codex 侧：--codex <thread-id> 或 @<thread-id>，走 ChatGPT Desktop 原生跨任务通信
-  const codexFlag = parsed.flags.get("codex");
-  const codexTargets = [
-    ...(typeof codexFlag === "string" ? [codexFlag] : []),
-    ...codexThreads.filter((t) => t !== codexFlag),
-  ];
-  const codexSource = parsed.flags.get("codex-source");
+  const codexTargets = [...new Set([
+    ...(codexFlag !== undefined ? [codexFlag] : []),
+    ...codexThreads.map((thread) => thread.toLowerCase()).filter((thread) => thread !== codexFlag),
+  ])];
   const wakeInput = {
     channel,
     seq: message.seq,
@@ -295,7 +328,7 @@ async function cmdSend(parsed: Parsed): Promise<void> {
   for (const target of codexTargets) {
     const result = await wakeCodexTask({
       targetThreadId: target,
-      ...(typeof codexSource === "string" ? { sourceThreadId: codexSource } : {}),
+      ...(codexSource !== undefined ? { sourceThreadId: codexSource } : {}),
       ...wakeInput,
     });
     if (result.ok) {
@@ -303,8 +336,10 @@ async function cmdSend(parsed: Parsed): Promise<void> {
     } else if (result.reason === "unknown-outcome") {
       // 上游铁律：帧已写出但结果未知——如实报告、绝不重放
       console.log(M.codexUnknownOutcome(result.detail ?? ""));
+      markStoredDeliveryFailure("unknown");
     } else {
       console.log(M.codexFailed(result.reason, result.detail ?? ""));
+      markStoredDeliveryFailure("failed");
     }
   }
 
@@ -317,10 +352,12 @@ async function cmdSend(parsed: Parsed): Promise<void> {
     const resolved = resolveDmTarget(target);
     if (resolved?.ambiguousPiTargets !== undefined) {
       console.log(M.piWakeAmbiguous(target, resolved.ambiguousPiTargets));
+      markStoredDeliveryFailure("failed");
       continue;
     }
     if (resolved?.kind !== "pi" || resolved.piSession === undefined) {
       console.log(M.piWakeUnavailable(target));
+      markStoredDeliveryFailure("failed");
       continue;
     }
     const result = await wakePiSession(
@@ -330,8 +367,10 @@ async function cmdSend(parsed: Parsed): Promise<void> {
     if (result.ok) console.log(M.piWakeAccepted(target));
     else if (result.reason === "unknown-outcome") {
       console.log(M.piWakeUnknownOutcome(target, result.detail ?? ""));
+      markStoredDeliveryFailure("unknown");
     } else {
       console.log(M.piWakeFailed(target, result.reason, result.detail ?? ""));
+      markStoredDeliveryFailure("failed");
     }
   }
 
@@ -347,9 +386,14 @@ async function cmdSend(parsed: Parsed): Promise<void> {
     selfPids: selfPid === null ? [] : [selfPid],
     selfNames: [from],
   });
+  if (selection.targets.length > 0 && selection.unmatchedNames.length > 0) {
+    console.log(M.wakeNoMatch(selection.unmatchedNames.join(" @")));
+    markStoredDeliveryFailure("failed");
+  }
   if (selection.targets.length === 0) {
     const hint = selection.excludedSelf.length > 0 ? M.wakeSelfSkipped : "";
     console.log(`${M.wakeNoMatch(wakeNames.join(" @"))}${hint}`);
+    if (selection.unmatchedNames.length > 0) markStoredDeliveryFailure("failed");
     if (idleSubscriber !== null) subscribeIdle(idleSubscriber, []);
     return;
   }
@@ -360,6 +404,7 @@ async function cmdSend(parsed: Parsed): Promise<void> {
       console.log(M.wakeDelivered(target));
     } else {
       console.log(M.wakeFailed(target, outcome.result.reason));
+      markStoredDeliveryFailure("failed");
     }
   }
   if (idleSubscriber !== null) subscribeIdle(idleSubscriber, selection.targets);
@@ -497,13 +542,21 @@ async function cmdDm(parsed: Parsed): Promise<void> {
     });
     const label = `${resolved.claude.name ?? "?"}(pid ${resolved.claude.pid})`;
     if (outcome!.result.ok) console.log(M.wakeDelivered(label));
-    else console.log(M.wakeFailed(label, outcome!.result.reason));
+    else {
+      console.log(M.wakeFailed(label, outcome!.result.reason));
+      markStoredDeliveryFailure("failed");
+    }
     if (idleSubscriber !== null) subscribeIdle(idleSubscriber, [resolved.claude]);
   } else if (resolved.kind === "codex-task" && resolved.threadId !== undefined) {
     const result = await wakeCodexTask({ targetThreadId: resolved.threadId, ...wakeInput });
     if (result.ok) console.log(M.codexAccepted(result.targetThreadId, result.turnId));
-    else if (result.reason === "unknown-outcome") console.log(M.codexUnknownOutcome(result.detail ?? ""));
-    else console.log(M.codexFailed(result.reason, result.detail ?? ""));
+    else if (result.reason === "unknown-outcome") {
+      console.log(M.codexUnknownOutcome(result.detail ?? ""));
+      markStoredDeliveryFailure("unknown");
+    } else {
+      console.log(M.codexFailed(result.reason, result.detail ?? ""));
+      markStoredDeliveryFailure("failed");
+    }
     if (idleSubscriber !== null) subscribeIdle(idleSubscriber, []);
   } else if (resolved.kind === "pi" && resolved.piSessionId !== undefined) {
     if (resolved.piSession === undefined) {
@@ -518,16 +571,23 @@ async function cmdDm(parsed: Parsed): Promise<void> {
     if (result.ok) console.log(M.piWakeAccepted(resolved.name));
     else if (result.reason === "unknown-outcome") {
       console.log(M.piWakeUnknownOutcome(resolved.name, result.detail ?? ""));
+      markStoredDeliveryFailure("unknown");
     } else {
       console.log(M.piWakeFailed(resolved.name, result.reason, result.detail ?? ""));
+      markStoredDeliveryFailure("failed");
     }
     if (idleSubscriber !== null) subscribeIdle(idleSubscriber, []);
   } else if (resolved.kind === "cmux" && resolved.cmuxRef !== undefined) {
     // cmux surface 没有 ocs 名字：Reply:/Thread: 的 --as 用 dm 同款派生名 surface-N。
     const result = wakeCmuxSurface(resolved.cmuxRef, wakeNote({ ...wakeInput, receiver: resolved.name }));
     if (result.ok) console.log(M.dmCmuxWoken(result.ref));
-    else if (result.reason === "busy") console.log(M.dmCmuxBusy(resolved.cmuxRef));
-    else console.log(M.dmCmuxFailed(resolved.cmuxRef, result.detail ?? result.reason));
+    else if (result.reason === "busy") {
+      console.log(M.dmCmuxBusy(resolved.cmuxRef));
+      markStoredDeliveryFailure("failed");
+    } else {
+      console.log(M.dmCmuxFailed(resolved.cmuxRef, result.detail ?? result.reason));
+      markStoredDeliveryFailure("failed");
+    }
     if (idleSubscriber !== null) subscribeIdle(idleSubscriber, []);
   }
 }
@@ -883,6 +943,7 @@ ocs dm <name> "<text>" --inherit <old-dm-channel>  # one-time history binding
 ocs inbox                        # unread threads attributable to this identity
 ocs send <channel> "<text>"      # post into a channel; @<name> wakes that agent
 ocs send <channel> "<text>" --reply-to <seq>   # reply; also wakes the author of <seq>
+ocs send <channel> "<text>" --codex codex-<8hex>  # short ID from ocs who also works
 ocs read <channel>               # read new messages (your own fold to one line;
                                  # --include-self shows them; --json adds self:bool)
 ocs notify-when-idle <name>      # one-shot: notice here when <name> next goes idle/exits
@@ -895,6 +956,8 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
   use the full ID shown by \`ocs who --verbose\` only if a short prefix is ambiguous.
 - \`ocs who\` lists only Codex tasks claimed by an open Desktop renderer.
   \`ocs codex-sessions\` is rollout history and does not imply wakeability.
+  Codex wake also needs a second open task under the same Desktop renderer as
+  the source; \`--codex-source\` accepts either its full ID or short address.
 - A wake note you receive carries the message body (up to 4096 bytes; longer
   messages show the first 512 bytes plus a Thread: command). Claude-to-Claude DM
   replies use the short \`ocs dm <workspace-alias>\` form when that alias identifies
@@ -911,7 +974,10 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
   \`--notify-when-idle\` on send/dm). You get exactly one
   \`[Cross-session idle notice]\` when it goes idle or exits (immediately if it is
   already idle; expires after 6h). No polling, no "done yet?" messages.
-- Delivery honesty: "delivered to inbox" or "queued" does not mean the model read it.
+- Delivery honesty: \`stored #<channel> seq <n>\` means only that the append-only
+  log commit succeeded. Requested wakes report accepted, stored-only, or unknown
+  separately. Exit 2 means stored but wake failed; exit 3 means stored with an
+  unknown outcome. Never resend either result; inspect the printed channel/seq.
 - If a Codex task is not renderer-open, the message remains stored and will appear
   in that task's \`ocs inbox\`; opening/selecting its Desktop task enables direct wake.
 - To keep a conversation going, end your message with the peer's @name so they wake

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -14,7 +14,7 @@ export function detectLang(env: NodeJS.ProcessEnv = process.env): Lang {
 
 interface Catalog {
   help: string;
-  sent: (channel: string, seq: number) => string;
+  stored: (channel: string, seq: number) => string;
   wakeNoMatch: (names: string) => string;
   wakeSelfSkipped: string;
   wakeDelivered: (target: string) => string;
@@ -130,6 +130,7 @@ interface Catalog {
   failNoSelfName: string;
   failName: (name: string) => string;
   failFlagRequired: (flag: string) => string;
+  failCodexAddress: (flag: string, value: string) => string;
   failMissingValue: (flag: string) => string;
   failUnknownFlag: (flag: string) => string;
   failExtraArgs: (args: string) => string;
@@ -149,11 +150,15 @@ Usage:
   ocs inbox [--as <name>] [--json]
       List unread threads attributable to this identity; reading still uses the existing ocs read command.
   ocs send <channel> <body> [--as <name>] [--reply-to <seq>] [--no-wake]
-           [--notify-when-idle] [--codex <thread-id>] [--codex-source <thread-id>]
+           [--notify-when-idle] [--codex <thread-id|codex-8hex>]
+           [--codex-source <thread-id|codex-8hex>]
       Append to a channel. @<session-name> wakes a live Claude session;
       @pi-<session-id> wakes Pi; @<thread-id> or --codex targets ChatGPT Desktop.
       --reply-to <seq> also wakes the author of that seq.
       The wake note carries the body (≤4096 bytes) and a copy-paste Reply: line.
+      Codex wake needs the target open plus a second open task owned by the same Desktop renderer.
+      Exit 2 = stored but wake failed; exit 3 = stored and outcome unknown. Do not resend either:
+      the stored #channel/seq is the correlation key.
   ocs read <channel> [--as <name>] [--since <seq>] [--json] [--peek] [--include-self]
       Read new messages since your cursor, then advance it (--peek: don't).
       Your own messages fold to one line unless --include-self.
@@ -178,11 +183,12 @@ Usage:
 
 --as is optional inside Claude, Codex, and Pi sessions (auto-detected; OCS_NAME also works).
 Data directory: ~/.ocs (override with OCS_HOME). Language: OCS_LANG=en|zh.`,
-  sent: (channel, seq) => `sent #${channel} seq ${seq}`,
+  stored: (channel, seq) => `stored #${channel} seq ${seq}`,
   wakeNoMatch: (names) => `wake: no live Claude session matches @${names}`,
   wakeSelfSkipped: " (you mentioned yourself; skipped)",
   wakeDelivered: (target) => `wake: delivered to inbox → ${target}`,
-  wakeFailed: (target, reason) => `wake: failed → ${target}: ${reason}`,
+  wakeFailed: (target, reason) =>
+    `wake: stored-only → ${target}: ${reason} (message is already stored; do not resend)`,
   wakeNoteHeader: ({ sender, channel, seq, replyTo, ago }) => {
     const parts = [`seq ${seq}`];
     if (replyTo !== undefined) parts.push(`reply to seq ${replyTo}`);
@@ -212,12 +218,13 @@ Data directory: ~/.ocs (override with OCS_HOME). Language: OCS_LANG=en|zh.`,
     `  ${target} → notify ${subscriber} when idle  (expires in ${expiresIn}, id ${id})`,
   codexAccepted: (thread, turnId) => `wake(codex): turn accepted → task ${thread} (turnId ${turnId})`,
   codexUnknownOutcome: (detail) => `wake(codex): outcome unknown (frame was written — do NOT resend): ${detail}`,
-  codexFailed: (reason, detail) => `wake(codex): failed (${reason})${detail ? `: ${detail}` : ""}`,
+  codexFailed: (reason, detail) =>
+    `wake(codex): stored-only (${reason})${detail ? `: ${detail}` : ""} (message is already stored; do not resend)`,
   piWakeAccepted: (target) => `wake(pi): queued → ${target}`,
   piWakeUnknownOutcome: (target, detail) =>
     `wake(pi): outcome unknown for ${target} (frame was written — do NOT resend)${detail ? `: ${detail}` : ""}`,
   piWakeFailed: (target, reason, detail) =>
-    `wake(pi): failed → ${target} (${reason})${detail ? `: ${detail}` : ""}`,
+    `wake(pi): stored-only → ${target} (${reason})${detail ? `: ${detail}` : ""} (message is already stored; do not resend)`,
   piWakeUnavailable: (target) =>
     `wake(pi): ${target} is not a live registered Pi TUI — run \`ocs skill install\`, then restart Pi`,
   piWakeSelfSkipped: (target) => `wake(pi): ${target} is this Pi session; skipped`,
@@ -306,7 +313,7 @@ Local ocs and hosted party coexist fine: same-machine work stays on ocs, cross-m
   whoCurrentProject: "  [this project]",
   whoEmpty: "no reachable agents found — open a Claude Code, Codex, or Pi session",
   whoCmuxHint: "cmux not detected: terminal TUIs are not listed (they can still join channels themselves)",
-  dmSent: (target, channel, seq) => `dm → ${target} (channel ${channel}, seq ${seq})`,
+  dmSent: (target, channel, seq) => `dm stored → ${target} (channel ${channel}, seq ${seq})`,
   dmWorkspaceResolved: (requested, current, alias) =>
     `resolved ${requested} → ${current} via unique workspace alias ${alias}`,
   dmWorkspaceAmbiguous: (target, names) =>
@@ -338,6 +345,8 @@ Local ocs and hosted party coexist fine: same-machine work stays on ocs, cross-m
     "cannot infer sender name (not inside a registered Claude/Codex/Pi session). Pass --as <name> or export OCS_NAME",
   failName: (name) => `invalid name: ${name}`,
   failFlagRequired: (flag) => `--${flag} <value> is required`,
+  failCodexAddress: (flag, value) =>
+    `--${flag} must be a full thread id or an unambiguous codex-<8hex> address from \`ocs who\`: ${value}`,
   failMissingValue: (flag) => `--${flag} requires a value`,
   failUnknownFlag: (flag) => `unknown flag: --${flag}`,
   failExtraArgs: (args) => `unexpected extra arguments: ${args}`,
@@ -357,11 +366,15 @@ const zh: Catalog = {
   ocs inbox [--as <name>] [--json]
       列出能可靠归属给当前身份的未读线程；读取仍复用现有 ocs read 命令
   ocs send <channel> <body> [--as <name>] [--reply-to <seq>] [--no-wake]
-           [--notify-when-idle] [--codex <thread-id>] [--codex-source <thread-id>]
+           [--notify-when-idle] [--codex <thread-id|codex-8hex>]
+           [--codex-source <thread-id|codex-8hex>]
       往频道追加消息；@<会话名> 唤醒活 Claude 会话，@pi-<session-id>
       唤醒 Pi；@<thread-id> 或 --codex 投给 ChatGPT Desktop 任务
       --reply-to <seq> 同时唤醒那条消息的作者
       唤醒 note 直接带正文（≤4096 字节）和一行可直接复制的回复命令
+      Codex 唤醒要求目标 task 已打开，并且同一 Desktop renderer 下另有一个已打开的 source task
+      退出码 2 = 消息已落盘但唤醒失败；退出码 3 = 已落盘且结果未知。两者都不要重发：
+      已落盘的 #channel/seq 就是追查键
   ocs read <channel> [--as <name>] [--since <seq>] [--json] [--peek] [--include-self]
       从上次游标读新消息并推进游标；--peek 只读不推进
       自己发的消息默认折叠成一行，--include-self 完整显示
@@ -386,11 +399,11 @@ const zh: Catalog = {
 
 在 Claude、Codex、Pi 会话里 --as 可省略（自动识别；OCS_NAME 也行）。
 数据目录: ~/.ocs（OCS_HOME 可覆盖）。语言: OCS_LANG=en|zh。`,
-  sent: (channel, seq) => `已发送 #${channel} seq ${seq}`,
+  stored: (channel, seq) => `已落盘 #${channel} seq ${seq}`,
   wakeNoMatch: (names) => `wake: 没有匹配 @${names} 的活 Claude 会话`,
   wakeSelfSkipped: "（@ 到了自己，已跳过）",
   wakeDelivered: (target) => `wake: 已投递收件箱 → ${target}`,
-  wakeFailed: (target, reason) => `wake: 失败 → ${target}: ${reason}`,
+  wakeFailed: (target, reason) => `wake: 仅落盘 → ${target}: ${reason}（消息已经落盘，请勿重发）`,
   wakeNoteHeader: ({ sender, channel, seq, replyTo, ago }) => {
     const parts = [`seq ${seq}`];
     if (replyTo !== undefined) parts.push(`回复 seq ${replyTo}`);
@@ -415,12 +428,13 @@ const zh: Catalog = {
     `  ${target} 空闲时通知 ${subscriber}  （${expiresIn} 后过期，id ${id}）`,
   codexAccepted: (thread, turnId) => `wake(codex): turn 已接受 → task ${thread}（turnId ${turnId}）`,
   codexUnknownOutcome: (detail) => `wake(codex): 结果未知（帧已写出，勿重发）: ${detail}`,
-  codexFailed: (reason, detail) => `wake(codex): 失败（${reason}）${detail ? `: ${detail}` : ""}`,
+  codexFailed: (reason, detail) =>
+    `wake(codex): 仅落盘（${reason}）${detail ? `: ${detail}` : ""}（消息已经落盘，请勿重发）`,
   piWakeAccepted: (target) => `wake(pi): 已排队 → ${target}`,
   piWakeUnknownOutcome: (target, detail) =>
     `wake(pi): ${target} 结果未知（帧已写出，勿重发）${detail ? `: ${detail}` : ""}`,
   piWakeFailed: (target, reason, detail) =>
-    `wake(pi): 失败 → ${target}（${reason}）${detail ? `: ${detail}` : ""}`,
+    `wake(pi): 仅落盘 → ${target}（${reason}）${detail ? `: ${detail}` : ""}（消息已经落盘，请勿重发）`,
   piWakeUnavailable: (target) =>
     `wake(pi): ${target} 不是已登记的活 Pi TUI——先跑 \`ocs skill install\`，再重启 Pi`,
   piWakeSelfSkipped: (target) => `wake(pi): ${target} 是当前 Pi 会话，已跳过`,
@@ -506,7 +520,7 @@ const zh: Catalog = {
   whoCurrentProject: "  [当前项目]",
   whoEmpty: "没发现可达的 agent——开一个 Claude Code、Codex 或 Pi 会话",
   whoCmuxHint: "cmux 未检测到：终端 TUI 不在列表里（它们仍可自己进频道）",
-  dmSent: (target, channel, seq) => `dm → ${target}（频道 ${channel}，seq ${seq}）`,
+  dmSent: (target, channel, seq) => `dm 已落盘 → ${target}（频道 ${channel}，seq ${seq}）`,
   dmWorkspaceResolved: (requested, current, alias) =>
     `通过唯一工作区别名 ${alias} 解析 ${requested} → ${current}`,
   dmWorkspaceAmbiguous: (target, names) =>
@@ -533,6 +547,8 @@ const zh: Catalog = {
   failNoSelfName: "推断不出发送者名字（不在已登记的 Claude/Codex/Pi 会话里）。用 --as <name> 或 export OCS_NAME",
   failName: (name) => `名字不合法: ${name}`,
   failFlagRequired: (flag) => `--${flag} <value> 是必填项`,
+  failCodexAddress: (flag, value) =>
+    `--${flag} 必须是完整 thread id，或 \`ocs who\` 给出的唯一 codex-<8hex> 短地址：${value}`,
   failMissingValue: (flag) => `--${flag} 后面必须带值`,
   failUnknownFlag: (flag) => `未知参数: --${flag}`,
   failExtraArgs: (args) => `多余的参数: ${args}`,

--- a/src/wake.ts
+++ b/src/wake.ts
@@ -139,6 +139,8 @@ export interface WakeTargetSelection {
   targets: NativeClaudeSession[];
   /** 被排除的自身会话 pid（防自我唤醒回环）。 */
   excludedSelf: number[];
+  /** 没有任何精确名或唯一工作区别名命中的 mention。 */
+  unmatchedNames: string[];
 }
 
 /**
@@ -256,14 +258,19 @@ export function selectWakeTargets(
   const wanted = new Set(mentions);
   const sessions = listNativeSessions(options.env).filter((session) => session.name !== null);
   const selectedPids = new Set<number>();
+  const matchedNames = new Set<string>();
   for (const mention of wanted) {
     const exact = sessions.filter((session) => session.name === mention);
     if (exact.length > 0) {
+      matchedNames.add(mention);
       for (const session of exact) selectedPids.add(session.pid);
       continue;
     }
     const aliases = sessions.filter((session) => claudeWorkspaceTargetMatches(session, mention));
-    if (aliases.length === 1) selectedPids.add(aliases[0]!.pid);
+    if (aliases.length === 1) {
+      matchedNames.add(mention);
+      selectedPids.add(aliases[0]!.pid);
+    }
   }
   const targets: NativeClaudeSession[] = [];
   const excludedSelf: number[] = [];
@@ -275,7 +282,11 @@ export function selectWakeTargets(
     }
     targets.push(session);
   }
-  return { targets, excludedSelf };
+  return {
+    targets,
+    excludedSelf,
+    unmatchedNames: [...wanted].filter((mention) => !matchedNames.has(mention)),
+  };
 }
 
 export interface WakeOutcome {

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -29,11 +29,11 @@ function runCli(args: string[]): { code: number; stderr: string; stdout: string 
 }
 
 describe("命令级参数 schema", () => {
-  test("--codex 缺值：报错退出，绝不打印 sent", () => {
+  test("--codex 缺值：报错退出，绝不打印 stored", () => {
     const r = runCli(["send", "chat", "hello", "--as", "a", "--codex"]);
     expect(r.code).toBe(1);
     expect(r.stderr).toContain("--codex requires a value");
-    expect(r.stdout).not.toContain("sent");
+    expect(r.stdout).not.toContain("stored");
   });
 
   test("未知 flag 报错", () => {
@@ -51,7 +51,7 @@ describe("命令级参数 schema", () => {
   test("合法 send 正常走通", () => {
     const r = runCli(["send", "chat", "hello world", "--as", "a", "--no-wake"]);
     expect(r.code).toBe(0);
-    expect(r.stdout).toContain("sent #chat seq 1");
+    expect(r.stdout).toContain("stored #chat seq 1");
   });
 
   test("常见的 --help 与 who --json 都是有效命令", () => {

--- a/test/cli-e2e.test.ts
+++ b/test/cli-e2e.test.ts
@@ -470,7 +470,7 @@ describe("notify-when-idle（#5）端到端：真脱离终端的 watcher", () =>
       f.setPeer("idle");
       const r = await run(f, ["send", "chat", "do it @worker-a", "--as", "tester", "--notify-when-idle"]);
       expect(r.code).toBe(0);
-      expect(r.stdout).toContain("sent #chat seq 1");
+      expect(r.stdout).toContain("stored #chat seq 1");
       expect(r.stdout).toContain("wake: delivered to inbox → worker-a");
       expect(r.stdout).toContain("notify-when-idle: subscribed → worker-a");
       expect(r.stdout).toContain("already idle");

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { codexSessionsRoot, listCodexSessions } from "../src/codex-sessions.ts";
 import { discoverCodexDesktopOwners } from "../src/codex-ipc.ts";
+import { readMessages } from "../src/store.ts";
 import { pickCodexSourceThread, splitWakeMentions, wakeCodexTask } from "../src/wake.ts";
 import { autoCleanupTempDirs, tempDir } from "./tmp";
 
@@ -83,6 +84,7 @@ function fakeRouter(
     ownerOf?: (threadId: string) => string;
     withThreadC?: boolean;
     ignoreOwnerFor?: ReadonlySet<string>;
+    startTurnWithoutId?: boolean;
   } = {},
 ): FakeRouter {
   const codexHome = rolloutFixture({ withThreadC: options.withThreadC ?? false }).CODEX_HOME!;
@@ -113,7 +115,13 @@ function fakeRouter(
           reply({ handledByClientId: ownerOf(params.conversationId as string) });
         } else if (message.method === "thread-follower-start-turn") {
           startTurnRequests.push(params);
-          reply({ result: { result: { turn: { id: "turn-42" } } } });
+          reply({
+            result: {
+              result: {
+                turn: options.startTurnWithoutId ? {} : { id: "turn-42" },
+              },
+            },
+          });
         }
       }
     });
@@ -227,6 +235,107 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
       expect(String(toolOutput.output)).toContain("#dev");
       expect(String(toolOutput.output)).toContain("seq 9");
       expect(String(toolOutput.output)).toContain(THREAD_A); // source 钉进 envelope
+    } finally {
+      router.close();
+    }
+  });
+
+  test("send 的 --codex / --codex-source 直接接受 who 展示的短地址", async () => {
+    const router = fakeRouter();
+    try {
+      const result = await runCli(router, [
+        "send",
+        "dev",
+        "hello codex",
+        "--as",
+        "alice",
+        "--codex",
+        "codex-bbbbbbbb",
+        "--codex-source",
+        "codex-aaaaaaaa",
+      ]);
+
+      expect({ code: result.code, stderr: result.stderr }).toEqual({ code: 0, stderr: "" });
+      expect(result.stdout).toContain("stored #dev seq 1");
+      expect(result.stdout).toContain(`turn accepted → task ${THREAD_B}`);
+      expect(router.startTurnRequests.length).toBe(1);
+    } finally {
+      router.close();
+    }
+  });
+
+  test("Codex 唤醒失败返回 stored-only 与退出码 2，且已落盘消息不丢", async () => {
+    const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_A]) });
+    const home = tempDir("ocs-codex-stored-only-");
+    try {
+      const result = await runCli(router, [
+        "send",
+        "dev",
+        "persist once",
+        "--as",
+        "alice",
+        "--codex",
+        "codex-bbbbbbbb",
+      ], { OCS_HOME: home });
+
+      expect({ code: result.code, stderr: result.stderr }).toEqual({ code: 2, stderr: "" });
+      expect(result.stdout).toContain("stored #dev seq 1");
+      expect(result.stdout).toContain("wake(codex): stored-only (no-source)");
+      expect(result.stdout).toContain("message is already stored; do not resend");
+      expect(readMessages("dev", { env: { OCS_HOME: home } })).toMatchObject([
+        { seq: 1, from: "alice", body: "persist once" },
+      ]);
+      expect(router.startTurnRequests).toEqual([]);
+    } finally {
+      router.close();
+    }
+  });
+
+  test("Codex 唤醒结果未知返回退出码 3，且明确禁止重发", async () => {
+    const router = fakeRouter({ startTurnWithoutId: true });
+    const home = tempDir("ocs-codex-unknown-outcome-");
+    try {
+      const result = await runCli(router, [
+        "send",
+        "dev",
+        "persist exactly once",
+        "--as",
+        "alice",
+        "--codex",
+        "codex-bbbbbbbb",
+        "--codex-source",
+        "codex-aaaaaaaa",
+      ], { OCS_HOME: home });
+
+      expect({ code: result.code, stderr: result.stderr }).toEqual({ code: 3, stderr: "" });
+      expect(result.stdout).toContain("stored #dev seq 1");
+      expect(result.stdout).toContain("wake(codex): outcome unknown");
+      expect(result.stdout).toContain("do NOT resend");
+      expect(readMessages("dev", { env: { OCS_HOME: home } })).toHaveLength(1);
+      expect(router.startTurnRequests).toHaveLength(1);
+    } finally {
+      router.close();
+    }
+  });
+
+  test("无效 Codex 短地址在消息落盘前失败", async () => {
+    const router = fakeRouter();
+    const home = tempDir("ocs-codex-invalid-short-");
+    try {
+      const result = await runCli(router, [
+        "send",
+        "dev",
+        "must not persist",
+        "--as",
+        "alice",
+        "--codex",
+        "codex-deadbeef",
+      ], { OCS_HOME: home });
+
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("must be a full thread id or an unambiguous codex-<8hex>");
+      expect(result.stdout).toBe("");
+      expect(readMessages("dev", { env: { OCS_HOME: home } })).toEqual([]);
     } finally {
       router.close();
     }

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -53,7 +53,7 @@ done
 printf '%s\\n' '#!/bin/sh' \\
   'case "$1" in' \\
   '  help) exit 0 ;;' \\
-  '  version) echo "ocs 0.4.1" ;;' \\
+  '  version) echo "ocs 0.4.2" ;;' \\
   '  skill) echo "$*" >> "$INSTALL_TEST_BINARY_LOG" ;;' \\
   'esac' > "$dest/ocs"
 chmod +x "$dest/ocs"
@@ -95,11 +95,11 @@ describe("curl installer skill setup", () => {
     expect(result.stderr).toBe("");
     expect(existsSync(join(f.installDir, "ocs"))).toBe(true);
     expect(readFileSync(f.npxLog, "utf8").trim()).toBe(
-      "-y skills@1.5.23 add https://github.com/leeguooooo/open-cross-session/tree/v0.4.1/skills/ocs " +
+      "-y skills@1.5.23 add https://github.com/leeguooooo/open-cross-session/tree/v0.4.2/skills/ocs " +
         "--skill ocs --global --agent claude-code --agent codex --agent pi --yes",
     );
     expect(readFileSync(f.binaryLog, "utf8").trim()).toBe("skill install");
-    expect(result.stdout).toContain("skill registered via skills CLI (source: v0.4.1)");
+    expect(result.stdout).toContain("skill registered via skills CLI (source: v0.4.2)");
   });
 
   test("skills CLI failure keeps the binary install and runs the embedded fallback", async () => {

--- a/test/wake.test.ts
+++ b/test/wake.test.ts
@@ -207,10 +207,12 @@ describe("listNativeSessions / selectWakeTargets", () => {
 
       const hit = selectWakeTargets(["worker-a", "ghost"], { env: f.env });
       expect(hit.targets.map((s) => s.name)).toEqual(["worker-a"]);
+      expect(hit.unmatchedNames).toEqual(["ghost"]);
 
       const excluded = selectWakeTargets(["worker-a"], { selfPids: [process.pid], env: f.env });
       expect(excluded.targets).toEqual([]);
       expect(excluded.excludedSelf).toEqual([process.pid]);
+      expect(excluded.unmatchedNames).toEqual([]);
     } finally {
       f.server.close();
     }


### PR DESCRIPTION
Closes #23
Closes #21

AgentParty 自激循环与 execution debt 已转到上游：leeguooooo/AgentParty#1080。

## 改动

- `send`/`dm` 首先明确输出 stored，不再把日志持久化描述成送达。
- 请求过 wake 但失败时退出 2；结果未知时退出 3。两者都提示消息已经落盘、不可重发，并用 channel/seq 追查。
- `--codex` 与 `--codex-source` 接受 `ocs who` 展示的 `codex-<8hex>` 短地址；无效或歧义值在落盘前失败。
- CLI help、英文/中文 README 与安装 skill 同步说明 Desktop source/target 前置条件与退出码。
- #21 收敛为文档化边界：跨机器托管协作用 Agent Party；已有免密 SSH 时由 controller 直接调用 workbox 上的本地 OCS/Herdr，SSH 方向决定角色，不在 OCS 重造远程 runtime。
- 版本升到 0.4.2，并补 changelog/安装器版本回归。

## 验证

- `bun run check`: 136 pass / 0 fail，TypeScript 0 error
- 全量前后 `$TMPDIR` 中 `ocs-*` 目录：1622 → 1622（净增 0）
- 覆盖 accepted、stored-only/exit 2、unknown/exit 3、无效短地址零落盘、纯 self-wake 防回环。