### PR TITLE
fix(codex): 建连预算独立于 owner 探测 deadline（#28），并修掉开发机上稳定失败的用例

### DIFF
--- a/src/codex-ipc.ts
+++ b/src/codex-ipc.ts
@@ -143,6 +143,13 @@ export interface CodexDesktopIpcClientOptions {
   env?: NodeJS.ProcessEnv;
   clientType?: string;
   requestTimeoutMs?: number;
+  /**
+   * 建连 + initialize 的预算，独立于 requestTimeoutMs。
+   * owner 探测故意用很短的 deadline（CODEX_OWNER_PROBE_TIMEOUT_MS）来快速判定"没人认领"，
+   * 但那个 deadline 套到建连上就变成了误判：机器一忙，连 socket 都还没握上就超时，
+   * 调用方看到的是传输故障而不是"未认领"。两者是不同的预算，别复用。
+   */
+  connectTimeoutMs?: number;
   startTurnTimeoutMs?: number;
 }
 
@@ -179,12 +186,14 @@ export class CodexDesktopIpcClient implements CodexDesktopIpcTransport {
   private closed = false;
   private readonly socketPath: string;
   private readonly timeoutMs: number;
+  private readonly connectTimeoutMs: number;
   private readonly startTurnTimeoutMs: number;
   private readonly clientType: string;
 
   constructor(options: CodexDesktopIpcClientOptions = {}) {
     this.socketPath = codexDesktopIpcSocketPath(options.env ?? process.env);
     this.timeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.connectTimeoutMs = options.connectTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.startTurnTimeoutMs = options.startTurnTimeoutMs ?? 30_000;
     this.clientType = options.clientType ?? "ocs";
   }
@@ -198,11 +207,11 @@ export class CodexDesktopIpcClient implements CodexDesktopIpcTransport {
     socket.once("error", (error) => this.handleClose(error));
     socket.once("close", () => this.handleClose(new Error("ChatGPT Desktop IPC closed")));
     await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new CodexDesktopIpcUnavailableError(`ChatGPT Desktop IPC connect timed out`)), this.timeoutMs);
+      const timer = setTimeout(() => reject(new CodexDesktopIpcUnavailableError(`ChatGPT Desktop IPC connect timed out`)), this.connectTimeoutMs);
       socket.once("connect", () => { clearTimeout(timer); resolve(); });
       socket.once("error", (error) => { clearTimeout(timer); reject(error); });
     });
-    const response = await this.request("initialize", 0, { clientType: this.clientType });
+    const response = await this.request("initialize", 0, { clientType: this.clientType }, { timeoutMs: this.connectTimeoutMs });
     const id = object(response.result) && typeof response.result.clientId === "string"
       ? response.result.clientId
       : null;

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -14,6 +14,9 @@ import { join } from "node:path";
 import { autoCleanupTempDirs, tempDir } from "./tmp";
 
 autoCleanupTempDirs();
+// 冷启动 CLI 子进程可达数秒，负载下会撞上 bun 默认的 5s 单测预算（实测 5006.96ms
+// 超时红）。与 cli-e2e.test.ts 同样给 spawn CLI 的用例 60s。
+const T = 60_000;
 
 // review #14 回归：缺值/未知 flag/多余参数必须报错退出，不许静默吞掉。
 function runCli(args: string[]): { code: number; stderr: string; stdout: string } {
@@ -34,25 +37,25 @@ describe("命令级参数 schema", () => {
     expect(r.code).toBe(1);
     expect(r.stderr).toContain("--codex requires a value");
     expect(r.stdout).not.toContain("stored");
-  });
+  }, T);
 
   test("未知 flag 报错", () => {
     const r = runCli(["read", "chat", "--as", "a", "--sneaky"]);
     expect(r.code).toBe(1);
     expect(r.stderr).toContain("unknown flag: --sneaky");
-  });
+  }, T);
 
   test("read 多余 positional 报错", () => {
     const r = runCli(["read", "chat", "extra", "--as", "a"]);
     expect(r.code).toBe(1);
     expect(r.stderr).toContain("unexpected extra arguments");
-  });
+  }, T);
 
   test("合法 send 正常走通", () => {
     const r = runCli(["send", "chat", "hello world", "--as", "a", "--no-wake"]);
     expect(r.code).toBe(0);
     expect(r.stdout).toContain("stored #chat seq 1");
-  });
+  }, T);
 
   test("常见的 --help 与 who --json 都是有效命令", () => {
     const help = runCli(["--help"]);
@@ -62,7 +65,7 @@ describe("命令级参数 schema", () => {
     const who = runCli(["who", "--json"]);
     expect(who.code).toBe(0);
     expect(JSON.parse(who.stdout)).toHaveProperty("entries");
-  });
+  }, T);
 
   test("doctor --fix 一次修复三端 skill、Pi 扩展和数据目录权限", () => {
     const root = tempDir("ocs-doctor-fix-");
@@ -102,5 +105,5 @@ describe("命令级参数 schema", () => {
     expect(stdout).toContain("updated the ocs skill for Claude, Codex, and Pi");
     expect(stdout).toContain("direct-wake extension installed");
     expect(stdout).toContain("owner-only permissions");
-  });
+  }, T);
 });

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -85,6 +85,8 @@ function fakeRouter(
     withThreadC?: boolean;
     ignoreOwnerFor?: ReadonlySet<string>;
     startTurnWithoutId?: boolean;
+    /** 让 initialize 慢于 owner 探测 deadline，模拟机器繁忙时的建连开销。 */
+    delayInitializeMs?: number;
   } = {},
 ): FakeRouter {
   const codexHome = rolloutFixture({ withThreadC: options.withThreadC ?? false }).CODEX_HOME!;
@@ -109,7 +111,9 @@ function fakeRouter(
         const reply = (extra: Record<string, unknown>) =>
           socket.write(encodeFrame({ type: "response", requestId: message.requestId, resultType: "success", ...extra }));
         if (message.method === "initialize") {
-          reply({ result: { clientId: "test-client" } });
+          const send = () => reply({ result: { clientId: "test-client" } });
+          if (options.delayInitializeMs === undefined) send();
+          else setTimeout(send, options.delayInitializeMs);
         } else if (message.method === "thread-owner-discovery") {
           if (options.ignoreOwnerFor?.has(params.conversationId as string)) continue;
           reply({ handledByClientId: ownerOf(params.conversationId as string) });
@@ -379,6 +383,28 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
       });
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.sourceThreadId).toBe(THREAD_C);
+    } finally {
+      router.close();
+    }
+  });
+
+  // #28：owner 探测的 deadline 故意很短（判"没人认领"要快），但它一度也被当成建连预算。
+  // 机器一忙，30ms 还没握上 socket 就超时，调用方收到的是 failed（会被当传输故障重试），
+  // 而不是 not-open（该停靠 inbox）。建连必须有独立预算。
+  test("建连慢于 owner 探测 deadline 时，仍按未认领报 not-open，不退化成 failed", async () => {
+    const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_B]), delayInitializeMs: 120 });
+    try {
+      const result = await wakeCodexTask({
+        targetThreadId: THREAD_B,
+        channel: "dm-test",
+        body: "park me",
+        seq: 3,
+        from: "a",
+        env: router.env,
+        ownerDiscoveryTimeoutMs: 30,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toBe("not-open");
     } finally {
       router.close();
     }

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -14,6 +14,9 @@ autoCleanupTempDirs();
 const THREAD_A = "aaaaaaaa-1111-2222-3333-444444444444";
 const THREAD_B = "bbbbbbbb-1111-2222-3333-444444444444";
 const THREAD_C = "cccccccc-1111-2222-3333-444444444444";
+// 冷启动 CLI 子进程可达数秒，负载下会撞上 bun 默认的 5s 单测预算（实测 5006.96ms
+// 超时红）。与 cli-e2e.test.ts 同样给 spawn CLI 的用例 60s。
+const T = 60_000;
 const CLI = join(import.meta.dir, "..", "src", "cli.ts");
 
 function rolloutFixture(options: { withThreadC?: boolean } = {}): NodeJS.ProcessEnv {
@@ -187,7 +190,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
     } finally {
       router.close();
     }
-  });
+  }, T);
 
   test("ocs doctor 区分 router socket、当前 task ownership 与 rollout 历史", async () => {
     const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_B]) });
@@ -200,7 +203,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
     } finally {
       router.close();
     }
-  });
+  }, T);
 
   test("批量 owner 探测只返回被打开 renderer 认领的 task", async () => {
     const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_A]) });
@@ -266,7 +269,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
     } finally {
       router.close();
     }
-  });
+  }, T);
 
   test("Codex 唤醒失败返回 stored-only 与退出码 2，且已落盘消息不丢", async () => {
     const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_A]) });
@@ -293,7 +296,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
     } finally {
       router.close();
     }
-  });
+  }, T);
 
   test("Codex 唤醒结果未知返回退出码 3，且明确禁止重发", async () => {
     const router = fakeRouter({ startTurnWithoutId: true });
@@ -320,7 +323,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
     } finally {
       router.close();
     }
-  });
+  }, T);
 
   test("无效 Codex 短地址在消息落盘前失败", async () => {
     const router = fakeRouter();
@@ -343,7 +346,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
     } finally {
       router.close();
     }
-  });
+  }, T);
 
   test("source/target 不同 renderer 拒投（route-mismatch）", async () => {
     const router = fakeRouter({ ownerOf: (t) => (t === THREAD_B ? "renderer-1" : "renderer-2") });

--- a/test/roster.test.ts
+++ b/test/roster.test.ts
@@ -336,7 +336,13 @@ describe("resolveSelfName", () => {
   });
 
   test("Codex 会话直接使用宿主提供的 thread id，不再要求 --as", () => {
-    expect(resolveSelfName({ CODEX_THREAD_ID: THREAD.toUpperCase() })).toBe(THREAD);
+    // 必须把原生会话目录指到空目录：否则在 Claude 会话里跑这套测试时，
+    // findSelfClaudePid 会沿真实祖先链命中宿主会话并返回它的名字，
+    // CODEX_THREAD_ID 分支永远走不到（在开发机上稳定失败）。
+    expect(resolveSelfName({
+      CODEX_THREAD_ID: THREAD.toUpperCase(),
+      [CLAUDE_NATIVE_SESSIONS_DIR_ENV]: tempDir("ocs-no-sessions-"),
+    })).toBe(THREAD);
     expect(selfIdentity(THREAD)).toBe(`codex:${THREAD}`);
   });
 

--- a/test/temp-dirs.test.ts
+++ b/test/temp-dirs.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const TEST_DIR = new URL(".", import.meta.url).pathname;
+
+// #24 的回归守卫：临时目录泄漏是靠「每个测试文件自己挂 autoCleanupTempDirs()」
+// 修好的，帮助模块里挂不生效（bun 的 afterEach 只作用于调用它的文件）。这意味着
+// 新增测试文件时漏调一次就悄悄恢复泄漏，没有任何报错。这里从源码上钉死两件事。
+describe("临时目录清理（#24）", () => {
+  const sources = readdirSync(TEST_DIR)
+    .filter((name) => name.endsWith(".test.ts"))
+    .map((name) => ({ name, source: readFileSync(join(TEST_DIR, name), "utf8") }));
+
+  test("不得裸用 mkdtempSync 而不自行清理", () => {
+    const offenders = sources
+      .filter(({ source }) => source.includes("mkdtempSync(") && !source.includes("rmSync("))
+      .map(({ name }) => name);
+    expect(offenders).toEqual([]);
+  });
+
+  // 顶层 autoCleanupTempDirs() 是常规写法；helper 自己的测试直接调 cleanupTempDirs()
+  // 也算数，两者都会把目录删掉。
+  test("用了 tempDir() 的文件必须挂上清理", () => {
+    const offenders = sources
+      .filter(({ source }) => source.includes("tempDir("))
+      .filter(({ source }) => !source.includes("autoCleanupTempDirs()") && !source.includes("cleanupTempDirs("))
+      .map(({ name }) => name);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/test/temp-dirs.test.ts
+++ b/test/temp-dirs.test.ts
@@ -1,8 +1,42 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import ts from "typescript";
 
 const TEST_DIR = new URL(".", import.meta.url).pathname;
+type TestSource = { name: string; source: string };
+
+function calledFunctionNames(source: string): Set<string> {
+  const parsed = ts.createSourceFile("guard-input.test.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const names = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      if (ts.isIdentifier(node.expression)) names.add(node.expression.text);
+      else if (ts.isPropertyAccessExpression(node.expression)) names.add(node.expression.name.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(parsed);
+  return names;
+}
+
+function bareMkdtempSources(candidates: readonly TestSource[]): string[] {
+  return candidates
+    .filter(({ source }) => {
+      const calls = calledFunctionNames(source);
+      return calls.has("mkdtempSync") && !calls.has("rmSync");
+    })
+    .map(({ name }) => name);
+}
+
+function unguardedTempDirSources(candidates: readonly TestSource[]): string[] {
+  return candidates
+    .filter(({ source }) => {
+      const calls = calledFunctionNames(source);
+      return calls.has("tempDir") && !calls.has("autoCleanupTempDirs") && !calls.has("cleanupTempDirs");
+    })
+    .map(({ name }) => name);
+}
 
 // #24 的回归守卫：临时目录泄漏是靠「每个测试文件自己挂 autoCleanupTempDirs()」
 // 修好的，帮助模块里挂不生效（bun 的 afterEach 只作用于调用它的文件）。这意味着
@@ -13,19 +47,25 @@ describe("临时目录清理（#24）", () => {
     .map((name) => ({ name, source: readFileSync(join(TEST_DIR, name), "utf8") }));
 
   test("不得裸用 mkdtempSync 而不自行清理", () => {
-    const offenders = sources
-      .filter(({ source }) => source.includes("mkdtempSync(") && !source.includes("rmSync("))
-      .map(({ name }) => name);
-    expect(offenders).toEqual([]);
+    expect(bareMkdtempSources(sources)).toEqual([]);
   });
 
   // 顶层 autoCleanupTempDirs() 是常规写法；helper 自己的测试直接调 cleanupTempDirs()
   // 也算数，两者都会把目录删掉。
   test("用了 tempDir() 的文件必须挂上清理", () => {
-    const offenders = sources
-      .filter(({ source }) => source.includes("tempDir("))
-      .filter(({ source }) => !source.includes("autoCleanupTempDirs()") && !source.includes("cleanupTempDirs("))
-      .map(({ name }) => name);
-    expect(offenders).toEqual([]);
+    expect(unguardedTempDirSources(sources)).toEqual([]);
+  });
+
+  test("注释或字符串里的清理函数名不能骗过守卫", () => {
+    const fakeMkdtempCleanup = [{
+      name: "comment-only-rm.test.ts",
+      source: `mkdtempSync("prefix-"); // rmSync("not-really-called")\nconst decoy = "rmSync(";`,
+    }];
+    const fakeHelperCleanup = [{
+      name: "literal-only-helper.test.ts",
+      source: `tempDir("prefix-"); /* autoCleanupTempDirs() */\nconst decoy = "cleanupTempDirs(";`,
+    }];
+    expect(bareMkdtempSources(fakeMkdtempCleanup)).toEqual(["comment-only-rm.test.ts"]);
+    expect(unguardedTempDirSources(fakeHelperCleanup)).toEqual(["literal-only-helper.test.ts"]);
   });
 });


### PR DESCRIPTION
三条提交，一个产品缺陷 + 两处测试基建。

## 1. `fix(codex)`: 建连预算独立于 owner 探测 deadline — Closes #28

**这不只是测试红，是会导致错误重试的产品缺陷。**

owner 探测故意用 500ms 的短 deadline 来快速判定「没人认领」，但 `CodexDesktopIpcClient` 的 `connect()` 和 `initialize` 也用同一个 `this.timeoutMs`。机器一忙，socket 还没握上就超时，抛的是

```
ChatGPT Desktop IPC connect timed out
```

`classifyOwnerError` 只认 `"No ChatGPT renderer owns"` 和 `"thread-owner-discovery timed out"`，匹配不上就走 `transport` 分支 → `reason: "failed"`。

后果：`failed` 对调用方意味着传输故障、可以重试；而实际情况是目标没人认领，应当按 `not-open` 停靠 inbox。这正是 CLAUDE.md 铁律 10 明令禁止的——「未认领按 `not-open` 停靠 inbox，不当传输故障重试」。生产的 500ms 同样会被建连吃掉，一次繁忙就可能把「未认领」误判成「传输故障」去重放。

改动：`CodexDesktopIpcClientOptions` 加 `connectTimeoutMs`（默认 `DEFAULT_REQUEST_TIMEOUT_MS`），`connect()` 与 `initialize` 走它，`thread-owner-discovery` 仍走短的 `requestTimeoutMs`。两处 client 构造都不传该项，自动拿到独立预算。

回归测试：`fakeRouter` 加 `delayInitializeMs`，让 initialize 慢于 30ms 探测 deadline，断言结果仍是 `not-open`。**把修复摘掉这条会红**，且报的正是 issue 里的症状：

```
Expected: "not-open"
Received: "failed"
```

`codex.test.ts` 从 2/8 偶发失败变成 0/10 全绿。实测未拖慢 `ocs who`（有修复 1.13–1.46s，无修复 0.83–1.77s，区间重叠）。

> ⚠️ `src/codex-ipc.ts` 是从 AgentParty 主仓 vendored 的（CLAUDE.md 铁律 6），**这个修复应当回流上游**，否则下次同步会被覆盖。

## 2. `test`: 修掉开发机上稳定失败的四条用例

在跑着真实 Claude/Codex 会话的开发机上，`bun run check` 稳定红四条，没法当门禁用。两个原因，都不是产品缺陷：

**`resolveSelfName` 那条不 hermetic。** 测试传裸 `{ CODEX_THREAD_ID }`，没覆盖 `OCS_CLAUDE_NATIVE_SESSIONS_DIR`，于是读到真实 `~/.claude/sessions`；`findSelfClaudePid` 沿真实进程祖先链命中宿主会话并返回它的名字（`src/roster.ts:78-82` 在 `CODEX_THREAD_ID` 分支之前），该分支永远走不到——实测返回 `"open-cross-session-04"`。把会话目录指到空临时目录即可。

**其余三条是 bun 默认 5s 单测预算不够。** 凡是 spawn CLI 子进程的用例，冷启动就要数秒，负载下必然撞线；现场抓到一条恰好 `5006.96ms` 的超时。`test/cli-e2e.test.ts` 早就为此定了 `const T = 60_000` 并写明理由，只是 `codex.test.ts` 和 `cli-args.test.ts` 没跟上。补齐（含直接 `Bun.spawnSync` 的 `doctor --fix`）。

## 3. `test`: 临时目录清理的回归守卫（#24 后续）

#24 的修法要求每个测试文件顶层自己调 `autoCleanupTempDirs()`（帮助模块里挂 `afterEach` 不生效）。代价是新增测试文件时漏调一次就悄悄恢复泄漏，跑起来一切正常，只有磁盘慢慢变满。从源码上钉死两条：不得裸用 `mkdtempSync` 而不清理；用了 `tempDir()` 就必须挂上清理。

验证过守卫真会红：临时摘掉 `store.test.ts` 的 `autoCleanupTempDirs()` 后用例失败，恢复后通过。

## 验证

全量跑从「稳定 4 red」变成 **139 pass / 0 fail，连跑三轮全绿**；`bunx tsc --noEmit` 无输出。

相关：#27（cli-e2e 时序 flaky）仍开着——那边我给的统计数据被本 PR 修掉的这批环境依赖用例污染过，已在 issue 里更正。

https://claude.ai/code/session_01C97sfT3EAupkyxrtnufAFp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a separate connection timeout setting for socket connections and initialization handshakes, while preserving the existing timeout for regular requests.

* **Bug Fixes**
  * Improved handling when connection setup is slow and owner discovery times out.

* **Tests**
  * Expanded timeout coverage for CLI and connection scenarios.
  * Added safeguards to detect temporary-directory leaks in tests.
  * Improved test isolation for session and process discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->