### PR TITLE
feat(codex): Desktop 不可投递时降级到唯一匹配的活 cmux surface（#30）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .DS_Store
 *.log
 bun.lock
+.codex/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+本仓库的 agent 指引以 **[CLAUDE.md](./CLAUDE.md)** 为唯一真值源，Codex / 其他 agent 请直接读它。
+
+不要在这里复制一份：之前一次 `s/Claude/Codex/` 式的整份复制替出了三处事实错误
+（"Codex ↔ Codex"、"Codex 注入 ok:true"、不存在的 `src/Codex-inject.ts`），
+两份文件必然漂移。铁律、常用命令、路线图都只在 CLAUDE.md 维护。
+
+机器相关的 Codex 配置放 `.codex/`（已 gitignore），不进仓库。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Codex Desktop 明确不可投递时，自动降级唤醒唯一匹配的空闲 cmux Codex surface；匹配会验证标题 task 短 ID 与活 Codex 进程，陈旧 shell、多匹配和 IPC `unknown-outcome` 均 fail closed（#30）
+
 ## v0.4.2
 
 - 发送输出明确区分 `stored` 与 wake 结果；唤醒失败返回退出码 2、结果未知返回退出码 3，并提醒消息已落盘、不可重发

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The protocol is shared with Agent Party: [docs/wake-protocol.md](./docs/wake-pro
 | Target | How | Requirement |
 |---|---|---|
 | Interactive Claude Code session | `@<session name>` | Receiver sets `"crossSessionInbound": "accept"` in `~/.claude/settings.json`. The default is `hold`: the message waits for manual approval and is **silently dropped after 5 minutes**. `ocs doctor` checks this. |
-| ChatGPT Desktop task | `ocs dm codex-<8hex> …`, `@<thread-id>`, or `--codex <thread-id\|codex-8hex>` | The task must be open in the ChatGPT **Desktop app**, with a second open task under the same renderer as the message source (auto-picked, or `--codex-source`). |
+| ChatGPT Desktop task / cmux Codex TUI | `ocs dm codex-<8hex> …`, `@<thread-id>`, or `--codex <thread-id\|codex-8hex>` | Desktop delivery needs the task open plus a second open task under the same renderer. If that path is definitely unavailable, ocs safely falls back to a uniquely matched, idle cmux surface that still has a live Codex process. |
 | Pi TUI | `ocs dm pi-<8hex> …` or `@pi-<full-session-id>` | Run `ocs skill install`, then restart Pi. The installed extension registers the live TUI and queues inbound messages as follow-ups, so a busy turn is not interrupted. |
 | Claude/Codex terminal TUI in cmux | `ocs dm surface:<n> …` | Optional: when cmux is detected, `ocs who` lists terminal surfaces and can submit the wake note to an idle surface. A busy surface is left untouched. |
 | Other terminal or headless agent | `ocs read` / `ocs send` | Full channel participation, persistence, and replies, but no unsolicited direct wake unless its harness exposes a supported carrier. |
@@ -113,9 +113,13 @@ The protocol is shared with Agent Party: [docs/wake-protocol.md](./docs/wake-pro
 Delivery honesty: the first line says `stored #<channel> seq <n>` once the append-only log commit succeeds; it does not claim wake delivery. Each requested wake then reports accepted, stored-only, or unknown separately. Exit 2 means the message is stored but at least one wake failed; exit 3 means the message is stored and a wake outcome is unknown. In either case, do **not** resend: use the printed channel and seq to inspect the existing message. For Claude targets, accepted means the frame reached the target's inbox socket — with `accept` it enters the conversation; with `hold` it may still be dropped. Pi acceptance means its extension queued the message.
 
 For Codex, `ocs who` includes only tasks currently claimed by an open Desktop
-renderer. `ocs codex-sessions` is rollout history, not presence. A DM to a task
-that is no longer open remains in the append-only log and is reported as parked;
-the target can recover it with `ocs inbox`, but it is not described as woken.
+renderer. `ocs codex-sessions` is rollout history, not presence. When Desktop
+definitely reports `unavailable`, `not-open`, or `no-source`, ocs may reuse the
+same stored channel/seq to wake a uniquely matched idle cmux Codex surface. The
+fallback requires both an exact task suffix in the surface title and a live
+foreground Codex process; stale shells and ambiguous matches fail closed. It is
+never attempted after an unknown IPC outcome. Without a safe carrier match, the
+message stays in the append-only log for recovery with `ocs inbox`.
 
 ## Commands
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,7 +97,7 @@ Claude→Claude DM 的「回复」行优先使用发送方的唯一工作区别�
 | 目标 | 用法 | 前提 |
 |---|---|---|
 | 交互式 Claude Code 会话 | `@<会话名>` | 接收端在 `~/.claude/settings.json` 设 `"crossSessionInbound": "accept"`。默认值 `hold`：消息进待审队列，**5 分钟没人处理就被静默丢弃**。`ocs doctor` 会查这一项。 |
-| ChatGPT Desktop 任务 | `ocs dm codex-<8hex> …`、`@<thread-id>` 或 `--codex <thread-id\|codex-8hex>` | 任务要在 ChatGPT **Desktop 应用**里开着，且同一 renderer 下还有第二个打开的任务作消息来源（自动挑选，或 `--codex-source` 指定）。 |
+| ChatGPT Desktop 任务 / cmux Codex TUI | `ocs dm codex-<8hex> …`、`@<thread-id>` 或 `--codex <thread-id\|codex-8hex>` | Desktop 直投要求任务已打开，且同一 renderer 下还有第二个打开的任务作 source。该路径明确不可用时，ocs 会安全降级到唯一匹配、仍有活 Codex 进程且空闲的 cmux surface。 |
 | Pi TUI | `ocs dm pi-<8hex> …` 或 `@pi-<完整session-id>` | 先跑 `ocs skill install`，再重启 Pi。扩展会登记活着的 TUI；消息在 Pi 忙碌时排到当前任务结束后，不会打断这一轮。 |
 | cmux 里的 Claude/Codex TUI | `ocs dm surface:<n> …` | 可选能力。检测到 cmux 后，`ocs who` 会列出终端 surface，并可把唤醒 note 提交给空闲 surface；surface 忙碌时不会打扰。 |
 | 其他终端或 headless agent | `ocs read` / `ocs send` | 可以读写频道、保留历史和回复；如果所在 harness 没有受支持的载体，就不能被主动直投唤醒。 |
@@ -106,8 +106,10 @@ Claude→Claude DM 的「回复」行优先使用发送方的唯一工作区别�
 投递语义分两层：首行 `已落盘 #<channel> seq <n>` 只表示 append-only 日志提交成功，不代表已经唤醒。随后每个 wake 请求分别报告已接受、仅落盘或结果未知。退出码 2 表示消息已落盘但至少一次唤醒失败；退出码 3 表示已落盘且唤醒结果未知。两种情况都不要重发，应使用输出里的 channel/seq 查原消息。Claude 的“已投递收件箱”只代表帧到了 socket；`accept` 下进入对话，`hold` 下仍可能被丢。Pi 的“已排队”表示扩展已接收。
 
 Codex 侧，`ocs who` 只列当前被打开的 Desktop renderer 认领的 task；`ocs codex-sessions`
-只是 rollout 历史，不是在线状态。发给已关闭 task 的 DM 仍会写入 append-only 日志并明确标为停靠，
-目标之后可用 `ocs inbox` 找回，但不会被描述成已经唤醒。
+只是 rollout 历史，不是在线状态。当 Desktop 明确返回 `unavailable`、`not-open` 或 `no-source`
+时，ocs 可以复用同一条已落盘消息的 channel/seq，唤醒唯一匹配且空闲的 cmux Codex surface。
+降级必须同时满足标题尾部 task 短 ID 精确匹配和前台 Codex 进程仍存活；陈旧 shell、多重匹配一律
+fail closed，IPC 结果未知时绝不降级。没有安全载体时，消息继续留在日志中供 `ocs inbox` 找回。
 
 ## 命令
 

--- a/skills/ocs/SKILL.md
+++ b/skills/ocs/SKILL.md
@@ -53,6 +53,9 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
   unknown outcome. Never resend either result; inspect the printed channel/seq.
 - If a Codex task is not renderer-open, the message remains stored and will appear
   in that task's `ocs inbox`; opening/selecting its Desktop task enables direct wake.
+  When Desktop definitely cannot deliver, ocs can fall back to a unique idle cmux
+  surface whose title and live Codex process match that task. It never falls back
+  after an unknown IPC outcome or when the surface match is ambiguous.
 - To keep a conversation going, end your message with the peer's @name so they wake
   (you are never woken by your own @).
 - Replying with `ocs dm <workspace-alias>` reuses the stable or explicitly

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,7 @@ import {
 import {
   buildRoster,
   dmChannel,
+  findCodexCmuxSurface,
   findDmReplyChannel,
   resolveDmTarget,
   resolveSelfName,
@@ -75,6 +76,7 @@ import {
   wakeCodexTask,
   wakeNote,
   wakeSessions,
+  type WakeNoteInput,
 } from "./wake.ts";
 
 export const OCS_VERSION = "0.4.2";
@@ -218,6 +220,31 @@ function resolveCodexFlagAddress(flag: "codex" | "codex-source", value: string):
   fail(M.failCodexAddress(flag, value));
 }
 
+/**
+ * #30：Desktop 明确没有投递时，若同一个 task 仍运行在唯一可验证的 cmux Codex surface，
+ * 用同一条已落盘消息的 channel/seq 唤醒它。unknown-outcome 绝不能走这里，避免重复投递。
+ */
+function tryCodexCmuxFallback(
+  targetThreadId: string,
+  reason: string,
+  wakeInput: Omit<WakeNoteInput, "receiver">,
+): boolean {
+  if (reason !== "unavailable" && reason !== "not-open" && reason !== "no-source") return false;
+  const surface = findCodexCmuxSurface(targetThreadId);
+  if (surface === null) return false;
+  const result = wakeCmuxSurface(
+    surface.ref,
+    wakeNote({
+      ...wakeInput,
+      receiver: `codex-${targetThreadId.slice(0, 8)}`,
+      implicitReceiver: true,
+    }),
+  );
+  if (!result.ok) return false;
+  console.log(M.codexCmuxFallback(targetThreadId, reason, surface.ref));
+  return true;
+}
+
 function printMessage(m: { seq: number; ts: string; from: string; body: string }): void {
   console.log(`#${m.seq} ${m.ts} <${m.from}> ${m.body}`);
 }
@@ -337,6 +364,8 @@ async function cmdSend(parsed: Parsed): Promise<void> {
       // 上游铁律：帧已写出但结果未知——如实报告、绝不重放
       console.log(M.codexUnknownOutcome(result.detail ?? ""));
       markStoredDeliveryFailure("unknown");
+    } else if (tryCodexCmuxFallback(target, result.reason, wakeInput)) {
+      // cmux 只复用同一 channel/seq 做唤醒，没有再次落盘。
     } else {
       console.log(M.codexFailed(result.reason, result.detail ?? ""));
       markStoredDeliveryFailure("failed");
@@ -553,6 +582,8 @@ async function cmdDm(parsed: Parsed): Promise<void> {
     else if (result.reason === "unknown-outcome") {
       console.log(M.codexUnknownOutcome(result.detail ?? ""));
       markStoredDeliveryFailure("unknown");
+    } else if (tryCodexCmuxFallback(resolved.threadId, result.reason, wakeInput)) {
+      // cmux 只复用同一 channel/seq 做唤醒，没有再次落盘。
     } else {
       console.log(M.codexFailed(result.reason, result.detail ?? ""));
       markStoredDeliveryFailure("failed");
@@ -980,6 +1011,9 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
   unknown outcome. Never resend either result; inspect the printed channel/seq.
 - If a Codex task is not renderer-open, the message remains stored and will appear
   in that task's \`ocs inbox\`; opening/selecting its Desktop task enables direct wake.
+  When Desktop definitely cannot deliver, ocs can fall back to a unique idle cmux
+  surface whose title and live Codex process match that task. It never falls back
+  after an unknown IPC outcome or when the surface match is ambiguous.
 - To keep a conversation going, end your message with the peer's @name so they wake
   (you are never woken by your own @).
 - Replying with \`ocs dm <workspace-alias>\` reuses the stable or explicitly

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -38,6 +38,7 @@ interface Catalog {
   codexAccepted: (thread: string, turnId: string) => string;
   codexUnknownOutcome: (detail: string) => string;
   codexFailed: (reason: string, detail: string) => string;
+  codexCmuxFallback: (thread: string, reason: string, ref: string) => string;
   piWakeAccepted: (target: string) => string;
   piWakeUnknownOutcome: (target: string, detail: string) => string;
   piWakeFailed: (target: string, reason: string, detail: string) => string;
@@ -220,6 +221,8 @@ Data directory: ~/.ocs (override with OCS_HOME). Language: OCS_LANG=en|zh.`,
   codexUnknownOutcome: (detail) => `wake(codex): outcome unknown (frame was written — do NOT resend): ${detail}`,
   codexFailed: (reason, detail) =>
     `wake(codex): stored-only (${reason})${detail ? `: ${detail}` : ""} (message is already stored; do not resend)`,
+  codexCmuxFallback: (thread, reason, ref) =>
+    `wake(codex): Desktop ${reason} for ${thread}; woke terminal ${ref} via cmux fallback`,
   piWakeAccepted: (target) => `wake(pi): queued → ${target}`,
   piWakeUnknownOutcome: (target, detail) =>
     `wake(pi): outcome unknown for ${target} (frame was written — do NOT resend)${detail ? `: ${detail}` : ""}`,
@@ -430,6 +433,8 @@ const zh: Catalog = {
   codexUnknownOutcome: (detail) => `wake(codex): 结果未知（帧已写出，勿重发）: ${detail}`,
   codexFailed: (reason, detail) =>
     `wake(codex): 仅落盘（${reason}）${detail ? `: ${detail}` : ""}（消息已经落盘，请勿重发）`,
+  codexCmuxFallback: (thread, reason, ref) =>
+    `wake(codex): Desktop 对 ${thread} 返回 ${reason}；已自动降级由 cmux 唤醒终端 ${ref}`,
   piWakeAccepted: (target) => `wake(pi): 已排队 → ${target}`,
   piWakeUnknownOutcome: (target, detail) =>
     `wake(pi): ${target} 结果未知（帧已写出，勿重发）${detail ? `: ${detail}` : ""}`,

--- a/src/roster.ts
+++ b/src/roster.ts
@@ -116,6 +116,10 @@ export interface CmuxSurface {
   title: string;
 }
 
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function cmuxAvailable(): boolean {
   try {
     return spawnSync("cmux", ["ping"], { encoding: "utf8", timeout: 2000 }).status === 0;
@@ -141,6 +145,69 @@ export function listCmuxSurfaces(): CmuxSurface[] {
     if (match) surfaces.push({ ref: match[1]!, title: match[2]! });
   }
   return surfaces;
+}
+
+/**
+ * 从 `cmux top --all --processes --json` 里只取仍有前台 Codex 进程的 terminal surface。
+ * 自动降级绝不能只信可能陈旧/可伪造的标题，否则 Codex 退出后会把唤醒正文敲进 shell。
+ */
+export function parseActiveCodexCmuxSurfaces(value: unknown): CmuxSurface[] {
+  const surfaces: CmuxSurface[] = [];
+  const seen = new Set<string>();
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) visit(item);
+      return;
+    }
+    if (!record(node)) return;
+    if (
+      node.kind === "surface" &&
+      typeof node.ref === "string" && /^surface:\d+$/.test(node.ref) &&
+      typeof node.title === "string" &&
+      Array.isArray(node.processes) &&
+      node.processes.some((process) =>
+        record(process) && process.kind === "process" && process.name === "codex"
+      )
+    ) {
+      if (!seen.has(node.ref)) {
+        seen.add(node.ref);
+        surfaces.push({ ref: node.ref, title: node.title });
+      }
+      return;
+    }
+    for (const child of Object.values(node)) visit(child);
+  };
+  visit(value);
+  return surfaces;
+}
+
+function listActiveCodexCmuxSurfaces(): CmuxSurface[] {
+  try {
+    const proc = spawnSync("cmux", ["top", "--all", "--processes", "--json"], {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    if (proc.status !== 0) return [];
+    return parseActiveCodexCmuxSurfaces(JSON.parse(proc.stdout) as unknown);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * #30：给 Desktop 未认领的 Codex task 找唯一的活 cmux TUI 兜底。
+ * cmux 自动标题以 `codex-<8hex>[-suffix]` 收尾；多命中或非活 Codex surface 都 fail closed。
+ */
+export function findCodexCmuxSurface(
+  threadId: string,
+  surfaces?: readonly CmuxSurface[],
+): CmuxSurface | null {
+  if (!isCodexThreadId(threadId)) return null;
+  const prefix = threadId.slice(0, 8).toLowerCase();
+  const suffix = new RegExp(`(?:^|[^a-z0-9])codex-${prefix}(?:-[0-9a-f]+)?$`, "i");
+  const matches = (surfaces ?? listActiveCodexCmuxSurfaces())
+    .filter(({ title }) => suffix.test(title.trim()));
+  return matches.length === 1 ? matches[0]! : null;
 }
 
 export type CmuxWakeResult =

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { codexSessionsRoot, listCodexSessions } from "../src/codex-sessions.ts";
 import { discoverCodexDesktopOwners } from "../src/codex-ipc.ts";
-import { readMessages } from "../src/store.ts";
+import { appendMessage, readMessages } from "../src/store.ts";
 import { pickCodexSourceThread, splitWakeMentions, wakeCodexTask } from "../src/wake.ts";
 import { autoCleanupTempDirs, tempDir } from "./tmp";
 
@@ -136,6 +136,50 @@ function fakeRouter(
   server.listen(sockPath);
   chmodSync(sockPath, 0o600);
   return { env: { CODEX_HOME: codexHome }, server, startTurnRequests, close: () => server.close() };
+}
+
+function fakeCmux(
+  threadId: string,
+  options: { busy?: boolean } = {},
+): { env: Record<string, string>; log: string } {
+  const root = tempDir("ocs-codex-cmux-");
+  const bin = join(root, "bin");
+  const log = join(root, "cmux.log");
+  mkdirSync(bin);
+  writeFileSync(log, "");
+  const top = JSON.stringify({
+    windows: [{
+      workspaces: [{
+        panes: [{
+          surfaces: [{
+            kind: "surface",
+            ref: "surface:77",
+            title: `open-cross-session · codex-${threadId.slice(0, 8)}-1`,
+            processes: [{ kind: "process", name: "codex" }],
+          }],
+        }],
+      }],
+    }],
+  });
+  const screen = options.busy ? "Working (esc to interrupt)" : "› Ask Codex to do anything";
+  const executable = join(bin, "cmux");
+  writeFileSync(executable, `#!/bin/sh
+case "$1" in
+  ping) exit 0 ;;
+  top) printf '%s\\n' '${top}' ;;
+  read-screen) printf '%s\\n' '${screen}' ;;
+  send|send-key) printf '%s\\n' "$*" >> "$OCS_TEST_CMUX_LOG" ;;
+  *) exit 1 ;;
+esac
+`);
+  chmodSync(executable, 0o700);
+  return {
+    env: {
+      PATH: `${bin}:/usr/bin:/bin`,
+      OCS_TEST_CMUX_LOG: log,
+    },
+    log,
+  };
 }
 
 async function runCli(
@@ -298,8 +342,72 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
     }
   }, T);
 
+  test("#30：Desktop 明确未认领时自动降级到唯一的活 cmux Codex surface", async () => {
+    const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_B]) });
+    const cmux = fakeCmux(THREAD_B);
+    const home = tempDir("ocs-codex-cmux-fallback-");
+    try {
+      appendMessage({
+        channel: "dev",
+        from: THREAD_B,
+        from_identity: `codex:${THREAD_B}`,
+        to_identity: "name:alice",
+        body: "please report back",
+        env: { OCS_HOME: home },
+      });
+      const result = await runCli(router, [
+        "send",
+        "dev",
+        "reply through the same stored message",
+        "--as",
+        "alice",
+        "--reply-to",
+        "1",
+      ], { ...cmux.env, OCS_HOME: home });
+
+      expect({ code: result.code, stderr: result.stderr }).toEqual({ code: 0, stderr: "" });
+      expect(result.stdout).toContain("stored #dev seq 2");
+      expect(result.stdout).toContain(`Desktop not-open for ${THREAD_B}`);
+      expect(result.stdout).toContain("woke terminal surface:77 via cmux fallback");
+      expect(result.stdout).not.toContain("stored-only");
+      expect(readMessages("dev", { env: { OCS_HOME: home } })).toHaveLength(2);
+      const calls = readFileSync(cmux.log, "utf8");
+      expect(calls).toContain("send --surface surface:77 [ocs wake]");
+      expect(calls).toContain("reply to seq 1");
+      expect(calls).toContain("Thread: ocs read dev");
+      expect(calls).toContain("send-key --surface surface:77 enter");
+      expect(router.startTurnRequests).toEqual([]);
+    } finally {
+      router.close();
+    }
+  }, T);
+
+  test("#30：匹配到的 cmux Codex 正在工作时不敲键打断", async () => {
+    const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_B]) });
+    const cmux = fakeCmux(THREAD_B, { busy: true });
+    try {
+      const result = await runCli(router, [
+        "send",
+        "dev",
+        "do not interrupt",
+        "--as",
+        "alice",
+        "--codex",
+        THREAD_B,
+      ], cmux.env);
+
+      expect({ code: result.code, stderr: result.stderr }).toEqual({ code: 2, stderr: "" });
+      expect(result.stdout).toContain("wake(codex): stored-only (not-open)");
+      expect(readFileSync(cmux.log, "utf8")).toBe("");
+      expect(router.startTurnRequests).toEqual([]);
+    } finally {
+      router.close();
+    }
+  }, T);
+
   test("Codex 唤醒结果未知返回退出码 3，且明确禁止重发", async () => {
     const router = fakeRouter({ startTurnWithoutId: true });
+    const cmux = fakeCmux(THREAD_B);
     const home = tempDir("ocs-codex-unknown-outcome-");
     try {
       const result = await runCli(router, [
@@ -312,7 +420,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
         "codex-bbbbbbbb",
         "--codex-source",
         "codex-aaaaaaaa",
-      ], { OCS_HOME: home });
+      ], { ...cmux.env, OCS_HOME: home });
 
       expect({ code: result.code, stderr: result.stderr }).toEqual({ code: 3, stderr: "" });
       expect(result.stdout).toContain("stored #dev seq 1");
@@ -320,6 +428,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
       expect(result.stdout).toContain("do NOT resend");
       expect(readMessages("dev", { env: { OCS_HOME: home } })).toHaveLength(1);
       expect(router.startTurnRequests).toHaveLength(1);
+      expect(readFileSync(cmux.log, "utf8")).toBe("");
     } finally {
       router.close();
     }

--- a/test/roster.test.ts
+++ b/test/roster.test.ts
@@ -7,7 +7,9 @@ import {
   dmChannel,
   buildRoster,
   claudeWorkspaceAlias,
+  findCodexCmuxSurface,
   findDmReplyChannel,
+  parseActiveCodexCmuxSurfaces,
   resolveDmTarget,
   resolveSelfName,
   selfIdentity,
@@ -23,6 +25,39 @@ import { autoCleanupTempDirs, tempDir } from "./tmp";
 autoCleanupTempDirs();
 
 const THREAD = "aaaaaaaa-1111-2222-3333-444444444444";
+
+describe("Codex 的 cmux 安全降级", () => {
+  const top = (surfaces: unknown[]) => ({ windows: [{ workspaces: [{ panes: [{ surfaces }] }] }] });
+  const codexSurface = (ref: string, title: string) => ({
+    kind: "surface",
+    ref,
+    title,
+    processes: [{ kind: "process", name: "codex" }],
+  });
+
+  test("只从仍有前台 Codex 进程的 surface 中按标题尾部短 id 唯一匹配", () => {
+    const active = codexSurface("surface:27", "open-cross-session · Ping · codex-aaaaaaaa-1");
+    const staleShell = {
+      kind: "surface",
+      ref: "surface:28",
+      title: "stale · codex-aaaaaaaa-1",
+      processes: [{ kind: "process", name: "zsh" }],
+    };
+    const parsed = parseActiveCodexCmuxSurfaces(top([active, staleShell]));
+    expect(parsed).toEqual([{ ref: "surface:27", title: active.title }]);
+    expect(findCodexCmuxSurface(THREAD, parsed)).toEqual({ ref: "surface:27", title: active.title });
+  });
+
+  test("短 id 多命中、前缀更长或标题不以 task id 收尾时 fail closed", () => {
+    const exact = codexSurface("surface:27", "project · codex-aaaaaaaa-1");
+    const duplicate = codexSurface("surface:29", "other · codex-aaaaaaaa-2");
+    const longer = codexSurface("surface:30", "project · codex-aaaaaaaa0");
+    const embedded = codexSurface("surface:31", "codex-aaaaaaaa-1 · copied text");
+    expect(findCodexCmuxSurface(THREAD, [exact, duplicate])).toBeNull();
+    expect(findCodexCmuxSurface(THREAD, [longer, embedded])).toBeNull();
+    expect(findCodexCmuxSurface("not-a-thread", [exact])).toBeNull();
+  });
+});
 
 function sessionsFixture(options: { name?: string; cwd?: string } = {}): NodeJS.ProcessEnv {
   const dir = tempDir("ocs-roster-");


### PR DESCRIPTION
Closes #30。接替 #31（原为基于 #29 的 stacked PR，#29 squash 合并、分支删除后被 GitHub 自动关闭，无法重开）；两个提交已 rebase 到 main 之上。

## 改了什么

Claude 用 `--reply-to` 回复一个跑在 cmux 里的 Codex CLI task 时，消息已落盘但 Desktop IPC 返回 `not-open`，正在跑的 TUI 没被唤醒。现在 Desktop 明确返回 `unavailable` / `not-open` / `no-source` 之一时，从 `cmux top --all --processes --json` 里找**标题尾部精确匹配该 task 短 id、且仍有前台 codex 进程**的 surface；唯一命中才唤醒，复用同一条 channel/seq，不再次落盘。

以下一律 fail closed：IPC `unknown-outcome`（避免重复投递）、多重命中、标题匹配但没有活 codex 进程（陈旧 shell，否则会把唤醒正文敲进 shell）、cmux 输出解析失败、surface 忙碌（保持现有不打断行为）。

## 来源与 review

实现来自共享工作区里隔壁 Codex 会话留下的未提交改动，本次 review 后按原样提交。核对过的点：

- **`cmux top` 真实输出形状**：surface 节点确实自带 `processes[].name`，与 parser 一致。这一点不验证的话，形状对不上会让降级功能静默永不触发（fail-closed 的反面）。
- **进程名**：取内核 `comm`。本机真实 Codex 进程 `comm` 就是 `codex`；`codex-cxs`、`codex-code-mode` 等同类工具因精确匹配被排除，这是对的。
- **热路径开销**：`cmux top --all --processes --json` 实测 0.11s，可接受。
- **unknown-outcome 不降级**：用例在有可匹配 surface 的情况下断言 cmux 调用日志为空。
- **退出码**：降级成功路径不调 `markStoredDeliveryFailure`，exitCode 保持 0。
- **对 #29 零回退**：仅 3 行 import/参数扩展。

## 验证

`bun run check` 144 pass / 0 fail；全量连跑 3 轮全绿。

顺带在这次 review 里把上游最近两天的 8 个提交按 CLAUDE.md 铁律逐条对了一遍（seq 无独立缓存、锁抢占走 rename 认领、`isOcsMessage` 白名单与 `OcsMessage` 七字段严格一致、route sidecar 先写、wake 载荷 4096/512/5120 与协议文档一致），没发现问题。

## 附带的 hygiene 提交

- `AGENTS.md` 改为指向 `CLAUDE.md` 的薄指针。原文件是 `s/Claude/Codex/` 整份复制，替出三处事实错误（"Codex ↔ Codex"、"Codex 注入 ok:true"、不存在的 `src/Codex-inject.ts`）；两份必漂移，只留一个真值源。
- `.codex/` 进 `.gitignore`：`config.toml` 含本机绝对路径，属机器配置。

https://claude.ai/code/session_0152k5peS4FTrFMhCgRkLEVw



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a safe fallback for Codex message delivery: when ChatGPT Desktop is definitively unavailable, ocs can wake the uniquely matching idle cmux Codex terminal.
  - Fallback matching requires an exact task identifier and a live Codex process; ambiguous or stale matches are left for recovery through the inbox.
  - Unknown delivery outcomes never trigger fallback.

- **Documentation**
  - Updated English and Chinese guidance, changelog entries, and agent documentation to describe the fallback behavior and configuration conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->