### PR TITLE
feat: ocs upgrade 真的升级二进制，doctor 检查版本是否落后，发 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.4.3
 
+- `ocs upgrade` 真的升级二进制：查 GitHub 最新 Release，落后时复用 install.sh（sha256 校验 + 冒烟 + 原子替换）；`--check` 只报告；原来的托管版迁移指南移到 `--party`。此前该命令只打印迁移文案，装了旧版的用户无从得知有新版
+- `ocs doctor` 新增版本检查：二进制落后于最新 Release 时给出警告并指向 `ocs upgrade`；离线/CI 可用 `OCS_UPGRADE_CHECK=0` 跳过
+- Codex IPC 建连预算独立于 owner 探测 deadline：此前 500ms 的探测 deadline 也套在 socket 建连上，机器繁忙时「未认领」会被误报成可重试的传输故障 `failed`，而非应停靠 inbox 的 `not-open`（#28）
+- skill 文档补上安装/升级入口，agent 缺二进制时能自愈
 - Codex Desktop 明确不可投递时，自动降级唤醒唯一匹配的空闲 cmux Codex surface；匹配会验证标题 task 短 ID 与活 Codex 进程，陈旧 shell、多匹配和 IPC `unknown-outcome` 均 fail closed（#30）
 
 ## v0.4.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-cross-session",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "跨 agent 的 cross-session，本机直连，零服务器 — local-first personal agent party",
   "license": "MIT",
   "type": "module",

--- a/skills/ocs/SKILL.md
+++ b/skills/ocs/SKILL.md
@@ -8,6 +8,15 @@ description: Talk to any other AI coding agent on this machine (Claude Code sess
 Discover who is reachable, then message them. Channels are plumbing — you never
 need to create or manage them.
 
+## Install / upgrade
+
+If `ocs` is not on PATH, install the GitHub Release binary (no token needed):
+
+    curl -fsSL https://raw.githubusercontent.com/leeguooooo/open-cross-session/main/install.sh | sh
+
+Keep it current: `ocs upgrade` fetches the latest release (`ocs upgrade --check` only
+reports); `ocs doctor` warns when the installed binary is behind.
+
 ```bash
 ocs who                          # same-project peers + pending notices; you are marked
 ocs who --verbose                # raw IDs/paths for diagnostics

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,8 +78,15 @@ import {
   wakeSessions,
   type WakeNoteInput,
 } from "./wake.ts";
+import {
+  checkUpgrade,
+  OCS_INSTALL_SCRIPT_URL,
+  OCS_UPGRADE_INSTALLER_ENV,
+  runInstaller,
+  upgradeCheckEnabled,
+} from "./upgrade.ts";
 
-export const OCS_VERSION = "0.4.2";
+export const OCS_VERSION = "0.4.3";
 
 const LANG = detectLang();
 const M = messages(LANG);
@@ -119,7 +126,7 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
   watch: { value: ["interval-ms"], bool: [], minPos: 1, maxPos: 1 },
   doctor: { value: [], bool: ["fix"], minPos: 0, maxPos: 0 },
   skill: { value: [], bool: [], minPos: 1, maxPos: 1 },
-  upgrade: NO_ARGS,
+  upgrade: { value: [], bool: ["check", "party"], minPos: 0, maxPos: 0 },
   version: NO_ARGS,
   "--version": NO_ARGS,
   "--help": NO_ARGS,
@@ -826,6 +833,43 @@ function cmdCodexSessions(parsed: Parsed): void {
   for (const s of sessions) console.log(formatCodexSessionLine(s));
 }
 
+/** `ocs upgrade`：查最新 release 并复用 install.sh 升级；--check 只报告；--party 打印迁移指南。 */
+async function cmdUpgrade(parsed: Parsed): Promise<void> {
+  if (parsed.flags.has("party")) {
+    console.log(M.upgrade);
+    return;
+  }
+  console.log(M.upgradeChecking);
+  const check = await checkUpgrade(OCS_VERSION);
+  if (check.status === "unknown") {
+    console.error(M.upgradeCheckFailed(check.error));
+    process.exitCode = 1;
+    return;
+  }
+  if (check.status === "current") {
+    console.log(M.upgradeCurrent(check.current));
+    console.log(M.upgradePartyHint);
+    return;
+  }
+  if (check.status === "ahead") {
+    console.log(M.upgradeAhead(check.current, check.latest));
+    return;
+  }
+  console.log(M.upgradeBehind(check.current, check.latest));
+  if (parsed.flags.has("check")) return;
+  // installer 自带 sha256 校验 + 冒烟 + 原子替换；失败时现有二进制不受影响。
+  const local = process.env[OCS_UPGRADE_INSTALLER_ENV];
+  console.log(M.upgradeRunning(local ? `sh ${local}` : `curl -fsSL ${OCS_INSTALL_SCRIPT_URL} | sh`));
+  const run = runInstaller();
+  if (run.code === 0) {
+    console.log(M.upgradeDone);
+    console.log(M.upgradePartyHint);
+  } else {
+    console.error(M.upgradeFailed(String(run.code ?? "spawn-failed")));
+    process.exitCode = run.code ?? 1;
+  }
+}
+
 async function cmdDoctor(parsed: Parsed): Promise<void> {
   const ok = (s: string) => console.log(`  ✅ ${s}`);
   const warn = (s: string) => console.log(`  ⚠️  ${s}`);
@@ -866,6 +910,17 @@ async function cmdDoctor(parsed: Parsed): Promise<void> {
     }
   } else {
     warn(M.doctorSkillsMissing(missingSkills.length));
+  }
+
+  console.log(M.doctorVersion);
+  if (!upgradeCheckEnabled()) {
+    warn(M.doctorVersionSkipped);
+  } else {
+    const upgrade = await checkUpgrade(OCS_VERSION);
+    if (upgrade.status === "unknown") warn(M.doctorVersionUnknown(upgrade.error));
+    else if (upgrade.status === "current") ok(M.doctorVersionOk(upgrade.current));
+    else if (upgrade.status === "behind") warn(M.doctorVersionBehind(upgrade.current, upgrade.latest));
+    else ok(M.doctorVersionAhead(upgrade.current, upgrade.latest));
   }
 
   console.log(M.doctorCodex);
@@ -965,6 +1020,15 @@ description: Talk to any other AI coding agent on this machine (Claude Code sess
 
 Discover who is reachable, then message them. Channels are plumbing — you never
 need to create or manage them.
+
+## Install / upgrade
+
+If \`ocs\` is not on PATH, install the GitHub Release binary (no token needed):
+
+    curl -fsSL https://raw.githubusercontent.com/leeguooooo/open-cross-session/main/install.sh | sh
+
+Keep it current: \`ocs upgrade\` fetches the latest release (\`ocs upgrade --check\` only
+reports); \`ocs doctor\` warns when the installed binary is behind.
 
 \`\`\`bash
 ocs who                          # same-project peers + pending notices; you are marked
@@ -1173,7 +1237,7 @@ async function main(): Promise<void> {
       await cmdDoctor(parsed);
       break;
     case "upgrade":
-      console.log(M.upgrade);
+      await cmdUpgrade(parsed);
       break;
     case "watch":
       await cmdWatch(parsed);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -91,6 +91,21 @@ interface Catalog {
   doctorDataUnsafe: (path: string, mode: string) => string;
   doctorDataNotDirectory: (path: string) => string;
   upgrade: string;
+  upgradeChecking: string;
+  upgradeCurrent: (version: string) => string;
+  upgradeBehind: (current: string, latest: string) => string;
+  upgradeAhead: (current: string, latest: string) => string;
+  upgradeCheckFailed: (error: string) => string;
+  upgradeRunning: (command: string) => string;
+  upgradeDone: string;
+  upgradeFailed: (code: string) => string;
+  upgradePartyHint: string;
+  doctorVersion: string;
+  doctorVersionOk: (version: string) => string;
+  doctorVersionBehind: (current: string, latest: string) => string;
+  doctorVersionAhead: (current: string, latest: string) => string;
+  doctorVersionUnknown: (error: string) => string;
+  doctorVersionSkipped: string;
   failSendUsage: string;
   failDmUsage: string;
   failReadUsage: string;
@@ -178,8 +193,9 @@ Usage:
       data-directory permissions, and crossSessionInbound (backing up settings first).
   ocs skill install
       Install the ocs skill for Claude, Codex, and Pi, plus Pi's direct-wake extension.
-  ocs upgrade
-      Migration guide to hosted Agent Party (cross-machine channels).
+  ocs upgrade [--check | --party]
+      Upgrade the ocs binary to the latest GitHub Release. --check only reports;
+      --party prints the migration guide to hosted Agent Party (cross-machine channels).
   ocs version | help
 
 --as is optional inside Claude, Codex, and Pi sessions (auto-detected; OCS_NAME also works).
@@ -294,6 +310,21 @@ Data directory: ~/.ocs (override with OCS_HOME). Language: OCS_LANG=en|zh.`,
   3. History:   optionally export with \`ocs read <channel> --as migrator --peek --json\` and replay via party send
 
 Local ocs and hosted party coexist fine: same-machine work stays on ocs, cross-machine goes party.`,
+  upgradeChecking: "checking the latest GitHub Release…",
+  upgradeCurrent: (version) => `ocs ${version} is already the latest release`,
+  upgradeBehind: (current, latest) => `ocs ${current} is behind the latest release ${latest}`,
+  upgradeAhead: (current, latest) => `ocs ${current} is ahead of the latest release ${latest} (development build); nothing to do`,
+  upgradeCheckFailed: (error) => `could not determine the latest release: ${error}`,
+  upgradeRunning: (command) => `running installer: ${command}`,
+  upgradeDone: "upgrade complete — run `ocs version` to confirm",
+  upgradeFailed: (code) => `installer failed (exit ${code}); the existing binary was left untouched`,
+  upgradePartyHint: "cross-machine channels? see `ocs upgrade --party` for hosted Agent Party",
+  doctorVersion: "Version",
+  doctorVersionOk: (version) => `ocs ${version} is the latest release`,
+  doctorVersionBehind: (current, latest) => `ocs ${current} is behind ${latest} — run \`ocs upgrade\``,
+  doctorVersionAhead: (current, latest) => `ocs ${current} is ahead of the latest release ${latest} (development build)`,
+  doctorVersionUnknown: (error) => `could not check the latest release (${error}); run \`ocs upgrade --check\` when online`,
+  doctorVersionSkipped: "version check skipped (OCS_UPGRADE_CHECK=0)",
   failSendUsage: "usage: ocs send <channel> <body> [--as <name>]",
   failDmUsage: "usage: ocs dm <name-or-id> <body> [--as <name>]",
   failReadUsage: "usage: ocs read <channel> [--as <name>]",
@@ -396,8 +427,9 @@ const zh: Catalog = {
       并在备份后把 crossSessionInbound 设为 accept
   ocs skill install
       给 Claude、Codex、Pi 安装 ocs skill，并安装 Pi 直投扩展
-  ocs upgrade
-      迁移到托管版 Agent Party（跨机器、跨组织频道）
+  ocs upgrade [--check | --party]
+      把 ocs 二进制升级到最新 GitHub Release。--check 只报告不安装；
+      --party 打印迁移到托管版 Agent Party（跨机器频道）的指南。
   ocs version | help
 
 在 Claude、Codex、Pi 会话里 --as 可省略（自动识别；OCS_NAME 也行）。
@@ -503,6 +535,21 @@ const zh: Catalog = {
   3. 迁历史: ocs read <channel> --as migrator --peek --json 导出后用 party send 回放（可选）
 
 本地 ocs 与托管 party 可以并存：本机小事走 ocs，跨机协作走 party。`,
+  upgradeChecking: "正在查询 GitHub 最新 Release…",
+  upgradeCurrent: (version) => `ocs ${version} 已是最新版本`,
+  upgradeBehind: (current, latest) => `ocs ${current} 落后于最新版本 ${latest}`,
+  upgradeAhead: (current, latest) => `ocs ${current} 比最新版本 ${latest} 更新（开发版），无需操作`,
+  upgradeCheckFailed: (error) => `无法确定最新版本：${error}`,
+  upgradeRunning: (command) => `正在运行安装脚本：${command}`,
+  upgradeDone: "升级完成——运行 `ocs version` 确认",
+  upgradeFailed: (code) => `安装脚本失败（退出码 ${code}），现有二进制未改动`,
+  upgradePartyHint: "需要跨机器频道？看 `ocs upgrade --party` 了解托管版 Agent Party",
+  doctorVersion: "版本",
+  doctorVersionOk: (version) => `ocs ${version} 已是最新版本`,
+  doctorVersionBehind: (current, latest) => `ocs ${current} 落后于 ${latest}——运行 \`ocs upgrade\``,
+  doctorVersionAhead: (current, latest) => `ocs ${current} 比最新版本 ${latest} 更新（开发版）`,
+  doctorVersionUnknown: (error) => `无法检查最新版本（${error}）；联网后运行 \`ocs upgrade --check\``,
+  doctorVersionSkipped: "已跳过版本检查（OCS_UPGRADE_CHECK=0）",
   failSendUsage: "用法: ocs send <channel> <body> [--as <name>]",
   failDmUsage: "用法: ocs dm <名字或id> <内容> [--as <name>]",
   failReadUsage: "用法: ocs read <channel> [--as <name>]",

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -1,0 +1,111 @@
+// 二进制自升级：查 GitHub 最新 release → 比版本 → 跑 install.sh。
+//
+// 之前 `ocs upgrade` 只打印一段迁移到托管版 Agent Party 的文案，不做任何升级；
+// 用户装了 0.4.1 之后 0.4.2 发了也不知道，doctor 也不提醒。这里补齐两件事：
+//   1. `ocs upgrade`：真的升级（复用 install.sh，它已做 sha256 校验 + 冒烟 + 原子替换）
+//   2. `ocs doctor`：二进制落后于最新 release 时给一条 warn
+//
+// 网络和 installer 都留了环境变量注入口，测试用本地假服务器和假脚本跑通全路径，
+// 绝不在测试里碰真 GitHub。doctor 的检查用 OCS_UPGRADE_CHECK=0 可整体关掉，
+// 离线/CI 环境不受影响。
+import { spawnSync } from "node:child_process";
+
+export const OCS_REPO = "leeguooooo/open-cross-session";
+export const OCS_INSTALL_SCRIPT_URL = `https://raw.githubusercontent.com/${OCS_REPO}/main/install.sh`;
+export const OCS_LATEST_RELEASE_URL = `https://api.github.com/repos/${OCS_REPO}/releases/latest`;
+
+/** 覆盖最新 release 的查询地址（测试指向本地假服务器）。 */
+export const OCS_UPGRADE_LATEST_URL_ENV = "OCS_UPGRADE_LATEST_URL";
+/** 覆盖 installer：给一个本地脚本路径，用 `sh <path>` 跑，替代 `curl … | sh`。 */
+export const OCS_UPGRADE_INSTALLER_ENV = "OCS_UPGRADE_INSTALLER";
+/** 设为 "0" 时 doctor 跳过版本检查（离线、CI、测试）。 */
+export const OCS_UPGRADE_CHECK_ENV = "OCS_UPGRADE_CHECK";
+
+const LATEST_TIMEOUT_MS = 3000;
+
+export type Version = readonly [number, number, number];
+
+/** "v0.4.3" / "0.4.3" → [0,4,3]；非法返回 null。 */
+export function parseVersion(raw: string): Version | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(raw.trim());
+  if (m === null) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+export function compareVersions(a: Version, b: Version): -1 | 0 | 1 {
+  for (let i = 0; i < 3; i++) {
+    if (a[i]! < b[i]!) return -1;
+    if (a[i]! > b[i]!) return 1;
+  }
+  return 0;
+}
+
+export type UpgradeCheck =
+  | { status: "current" | "behind" | "ahead"; current: string; latest: string }
+  | { status: "unknown"; current: string; error: string };
+
+function latestReleaseUrl(env: NodeJS.ProcessEnv): string {
+  const override = env[OCS_UPGRADE_LATEST_URL_ENV];
+  return typeof override === "string" && override !== "" ? override : OCS_LATEST_RELEASE_URL;
+}
+
+/** 查最新 release 的 tag。任何失败（离线、限流、格式不对）都归 unknown，绝不抛。 */
+export async function fetchLatestVersion(
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = LATEST_TIMEOUT_MS,
+): Promise<{ tag: string } | { error: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(latestReleaseUrl(env), {
+      signal: controller.signal,
+      // GitHub API 无 UA 会 403。
+      headers: { "user-agent": "ocs-upgrade", accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) return { error: `HTTP ${response.status}` };
+    const body = (await response.json()) as unknown;
+    const tag = typeof body === "object" && body !== null && !Array.isArray(body)
+      ? (body as Record<string, unknown>).tag_name
+      : undefined;
+    if (typeof tag !== "string" || parseVersion(tag) === null) {
+      return { error: `unexpected release payload (tag_name=${JSON.stringify(tag)})` };
+    }
+    return { tag };
+  } catch (error) {
+    const e = error as { name?: string; message?: string };
+    return { error: e.name === "AbortError" ? `timed out after ${timeoutMs}ms` : String(e.message ?? error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function checkUpgrade(
+  current: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<UpgradeCheck> {
+  const cur = parseVersion(current);
+  if (cur === null) return { status: "unknown", current, error: `current version is not semver: ${current}` };
+  const latest = await fetchLatestVersion(env);
+  if ("error" in latest) return { status: "unknown", current, error: latest.error };
+  const lat = parseVersion(latest.tag)!;
+  const order = compareVersions(cur, lat);
+  return { status: order < 0 ? "behind" : order > 0 ? "ahead" : "current", current, latest: latest.tag };
+}
+
+export function upgradeCheckEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[OCS_UPGRADE_CHECK_ENV] !== "0";
+}
+
+/**
+ * 跑 installer。默认 `curl -fsSL <install.sh> | sh`；OCS_UPGRADE_INSTALLER 指向本地脚本时
+ * 改跑 `sh <path>`（测试用）。stdio 直通终端，用户能看到下载/校验/替换的每一步。
+ * 返回 installer 的退出码；起不来返回 null。
+ */
+export function runInstaller(env: NodeJS.ProcessEnv = process.env): { code: number | null; command: string } {
+  const local = env[OCS_UPGRADE_INSTALLER_ENV];
+  const argv = typeof local === "string" && local !== ""
+    ? ["sh", local]
+    : ["sh", "-c", `curl -fsSL ${OCS_INSTALL_SCRIPT_URL} | sh`];
+  const proc = spawnSync(argv[0]!, argv.slice(1), { stdio: "inherit", env });
+  return { code: proc.status, command: argv.join(" ") };
+}

--- a/test/cli-args.test.ts
+++ b/test/cli-args.test.ts
@@ -22,7 +22,7 @@ const T = 60_000;
 function runCli(args: string[]): { code: number; stderr: string; stdout: string } {
   const home = tempDir("ocs-cli-");
   const proc = Bun.spawnSync(["bun", join(import.meta.dir, "..", "src", "cli.ts"), ...args], {
-    env: { ...process.env, CODEX_HOME: join(home, "codex"), OCS_HOME: home, OCS_LANG: "en" },
+    env: { ...process.env, CODEX_HOME: join(home, "codex"), OCS_HOME: home, OCS_LANG: "en", OCS_UPGRADE_CHECK: "0" },
   });
   return {
     code: proc.exitCode,
@@ -90,6 +90,7 @@ describe("命令级参数 schema", () => {
         OCS_CLAUDE_SETTINGS_PATH: settings,
         PI_CODING_AGENT_DIR: piAgentDir,
         OCS_LANG: "en",
+        OCS_UPGRADE_CHECK: "0",
       },
     });
     const stdout = proc.stdout.toString();

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -192,6 +192,7 @@ async function runCli(
     ...router.env,
     OCS_HOME: tempDir("ocs-codex-cli-"),
     OCS_LANG: "en",
+    OCS_UPGRADE_CHECK: "0",
     ...extraEnv,
   } as Record<string, string>;
   delete env.CLAUDE_CODE_SESSION_ID;

--- a/test/upgrade.test.ts
+++ b/test/upgrade.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { OCS_VERSION } from "../src/cli.ts";
+import {
+  checkUpgrade,
+  compareVersions,
+  OCS_UPGRADE_CHECK_ENV,
+  OCS_UPGRADE_INSTALLER_ENV,
+  OCS_UPGRADE_LATEST_URL_ENV,
+  parseVersion,
+} from "../src/upgrade.ts";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
+
+const CLI = join(import.meta.dir, "..", "src", "cli.ts");
+// spawn CLI 冷启动可达数秒，负载下会撞 bun 默认 5s（与 cli-e2e.test.ts 同款预算）。
+const T = 60_000;
+
+const servers: ReturnType<typeof Bun.serve>[] = [];
+afterEach(() => {
+  for (const s of servers.splice(0)) s.stop(true);
+});
+
+/** 本地假 GitHub：按需返回 tag_name / 状态码，并记录被查询次数。 */
+function fakeGithub(reply: { tag?: string; status?: number }): { url: string; hits: () => number } {
+  let hits = 0;
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch() {
+      hits++;
+      if (reply.status !== undefined && reply.status !== 200) return new Response("nope", { status: reply.status });
+      return Response.json(reply.tag === undefined ? { junk: true } : { tag_name: reply.tag });
+    },
+  });
+  servers.push(server);
+  return { url: `http://127.0.0.1:${server.port}/latest`, hits: () => hits };
+}
+
+/** 假 installer：写一个 marker 文件然后按指定码退出，证明它被（或没被）调用。 */
+function fakeInstaller(exitCode = 0): { path: string; marker: string } {
+  const dir = tempDir("ocs-upgrade-");
+  const marker = join(dir, "installed.marker");
+  const path = join(dir, "install.sh");
+  writeFileSync(path, `#!/bin/sh\necho fake-installer-ran\ntouch "${marker}"\nexit ${exitCode}\n`);
+  chmodSync(path, 0o755);
+  return { path, marker };
+}
+
+function bump(v: string, by: number): string {
+  const [a, b, c] = parseVersion(v)!;
+  return `${a}.${b}.${c + by}`;
+}
+
+async function runCli(args: string[], extraEnv: Record<string, string>) {
+  const proc = Bun.spawn([process.execPath, CLI, ...args], {
+    env: { ...process.env, OCS_HOME: tempDir("ocs-upgrade-home-"), OCS_LANG: "en", ...extraEnv },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout, stderr };
+}
+
+describe("版本解析与比较", () => {
+  test("接受 v 前缀与裸三段，拒绝其他", () => {
+    expect(parseVersion("v0.4.3")).toEqual([0, 4, 3]);
+    expect(parseVersion("0.4.3")).toEqual([0, 4, 3]);
+    expect(parseVersion("0.4")).toBeNull();
+    expect(parseVersion("0.4.3-rc1")).toBeNull();
+    expect(parseVersion("latest")).toBeNull();
+  });
+
+  test("逐段数值比较，不是字符串比较", () => {
+    expect(compareVersions([0, 4, 3], [0, 4, 10])).toBe(-1);
+    expect(compareVersions([0, 10, 0], [0, 9, 9])).toBe(1);
+    expect(compareVersions([1, 0, 0], [1, 0, 0])).toBe(0);
+  });
+});
+
+describe("checkUpgrade（本地假 GitHub）", () => {
+  test("落后 / 一致 / 领先 三态", async () => {
+    const behind = fakeGithub({ tag: `v${bump(OCS_VERSION, 1)}` });
+    expect(await checkUpgrade(OCS_VERSION, { [OCS_UPGRADE_LATEST_URL_ENV]: behind.url }))
+      .toMatchObject({ status: "behind", latest: `v${bump(OCS_VERSION, 1)}` });
+    const same = fakeGithub({ tag: `v${OCS_VERSION}` });
+    expect(await checkUpgrade(OCS_VERSION, { [OCS_UPGRADE_LATEST_URL_ENV]: same.url }))
+      .toMatchObject({ status: "current" });
+    const ahead = fakeGithub({ tag: "v0.0.1" });
+    expect(await checkUpgrade(OCS_VERSION, { [OCS_UPGRADE_LATEST_URL_ENV]: ahead.url }))
+      .toMatchObject({ status: "ahead" });
+  });
+
+  test("HTTP 错误 / 载荷不对 / 连不上 都归 unknown，绝不抛", async () => {
+    const http = fakeGithub({ status: 403 });
+    expect(await checkUpgrade(OCS_VERSION, { [OCS_UPGRADE_LATEST_URL_ENV]: http.url }))
+      .toMatchObject({ status: "unknown", error: "HTTP 403" });
+    const junk = fakeGithub({});
+    expect((await checkUpgrade(OCS_VERSION, { [OCS_UPGRADE_LATEST_URL_ENV]: junk.url })).status).toBe("unknown");
+    const dead = await checkUpgrade(OCS_VERSION, { [OCS_UPGRADE_LATEST_URL_ENV]: "http://127.0.0.1:1/latest" });
+    expect(dead.status).toBe("unknown");
+  });
+});
+
+describe("ocs upgrade（端到端，假 GitHub + 假 installer）", () => {
+  test("落后时跑 installer，成功退出码 0，并附托管版提示", async () => {
+    const gh = fakeGithub({ tag: `v${bump(OCS_VERSION, 1)}` });
+    const inst = fakeInstaller(0);
+    const r = await runCli(["upgrade"], {
+      [OCS_UPGRADE_LATEST_URL_ENV]: gh.url,
+      [OCS_UPGRADE_INSTALLER_ENV]: inst.path,
+    });
+    expect({ code: r.code, stderr: r.stderr }).toEqual({ code: 0, stderr: "" });
+    expect(existsSync(inst.marker)).toBe(true);
+    expect(r.stdout).toContain(`v${bump(OCS_VERSION, 1)}`);
+    expect(r.stdout).toContain("ocs upgrade --party");
+  }, T);
+
+  test("installer 失败时透传其退出码", async () => {
+    const gh = fakeGithub({ tag: `v${bump(OCS_VERSION, 1)}` });
+    const inst = fakeInstaller(3);
+    const r = await runCli(["upgrade"], {
+      [OCS_UPGRADE_LATEST_URL_ENV]: gh.url,
+      [OCS_UPGRADE_INSTALLER_ENV]: inst.path,
+    });
+    expect(r.code).toBe(3);
+    expect(existsSync(inst.marker)).toBe(true);
+  }, T);
+
+  test("已是最新时不碰 installer", async () => {
+    const gh = fakeGithub({ tag: `v${OCS_VERSION}` });
+    const inst = fakeInstaller(0);
+    const r = await runCli(["upgrade"], {
+      [OCS_UPGRADE_LATEST_URL_ENV]: gh.url,
+      [OCS_UPGRADE_INSTALLER_ENV]: inst.path,
+    });
+    expect({ code: r.code, stderr: r.stderr }).toEqual({ code: 0, stderr: "" });
+    expect(existsSync(inst.marker)).toBe(false);
+    expect(r.stdout).toContain(OCS_VERSION);
+  }, T);
+
+  test("--check 只报告不安装；查不到最新版时退出码 1 且不安装", async () => {
+    const gh = fakeGithub({ tag: `v${bump(OCS_VERSION, 1)}` });
+    const inst = fakeInstaller(0);
+    const check = await runCli(["upgrade", "--check"], {
+      [OCS_UPGRADE_LATEST_URL_ENV]: gh.url,
+      [OCS_UPGRADE_INSTALLER_ENV]: inst.path,
+    });
+    expect(check.code).toBe(0);
+    expect(existsSync(inst.marker)).toBe(false);
+    expect(check.stdout).toContain(`v${bump(OCS_VERSION, 1)}`);
+
+    const down = fakeGithub({ status: 500 });
+    const inst2 = fakeInstaller(0);
+    const r = await runCli(["upgrade"], {
+      [OCS_UPGRADE_LATEST_URL_ENV]: down.url,
+      [OCS_UPGRADE_INSTALLER_ENV]: inst2.path,
+    });
+    expect(r.code).toBe(1);
+    expect(existsSync(inst2.marker)).toBe(false);
+    expect(r.stderr).toContain("HTTP 500");
+  }, T);
+
+  test("--party 只打印迁移指南，不联网不安装", async () => {
+    const gh = fakeGithub({ tag: `v${bump(OCS_VERSION, 1)}` });
+    const inst = fakeInstaller(0);
+    const r = await runCli(["upgrade", "--party"], {
+      [OCS_UPGRADE_LATEST_URL_ENV]: gh.url,
+      [OCS_UPGRADE_INSTALLER_ENV]: inst.path,
+    });
+    expect({ code: r.code, stderr: r.stderr }).toEqual({ code: 0, stderr: "" });
+    expect(r.stdout).toContain("agentparty.leeguoo.com");
+    expect(gh.hits()).toBe(0);
+    expect(existsSync(inst.marker)).toBe(false);
+  }, T);
+});
+
+describe("ocs doctor 的版本检查", () => {
+  test("落后时 warn 并指向 ocs upgrade；OCS_UPGRADE_CHECK=0 时跳过且不联网", async () => {
+    const gh = fakeGithub({ tag: `v${bump(OCS_VERSION, 1)}` });
+    const behind = await runCli(["doctor"], { [OCS_UPGRADE_LATEST_URL_ENV]: gh.url });
+    expect(behind.stderr).toBe("");
+    expect(behind.stdout).toContain(`v${bump(OCS_VERSION, 1)}`);
+    expect(behind.stdout).toContain("ocs upgrade");
+    expect(gh.hits()).toBe(1);
+
+    const gh2 = fakeGithub({ tag: `v${bump(OCS_VERSION, 1)}` });
+    const skipped = await runCli(["doctor"], { [OCS_UPGRADE_LATEST_URL_ENV]: gh2.url, [OCS_UPGRADE_CHECK_ENV]: "0" });
+    expect(skipped.stderr).toBe("");
+    expect(skipped.stdout).not.toContain(`v${bump(OCS_VERSION, 1)}`);
+    expect(gh2.hits()).toBe(0);
+  }, T);
+});


### PR DESCRIPTION
## 为什么

用户**不会自动更新**，三道坎一道都没通：

1. `ocs upgrade` 只打印一段迁移到托管版 Agent Party 的文案，不做任何升级
2. `ocs doctor` 只查 skill 文件，不查二进制版本；整个代码库没有任何地方查过 `releases/latest`
3. `SKILL.md` 一个字没提 `install.sh`，agent 装了 skill 也不知道怎么装/更新二进制

现成证据：这台开发机还跑着 0.4.1，而 v0.4.2 昨天就发了。#28/#30 合进 main 后同样没人拿得到。

## 改了什么

**新增 `src/upgrade.ts`**
- `fetchLatestVersion`：查 `releases/latest` 的 `tag_name`，3s 超时，任何失败归 `unknown` 绝不抛；带 UA（GitHub API 无 UA 会 403）
- `compareVersions`：逐段数值比较，不是字符串比较
- `runInstaller`：复用 `install.sh`（已有 sha256 校验 + 冒烟 + 原子替换），失败时现有二进制不受影响，退出码原样透传

**`ocs upgrade`**：落后时跑 installer；`--check` 只报告；查不到最新版退出码 1 且不安装；原迁移指南移到 `--party`，完整保留。

**`ocs doctor`**：新增 Version 段，落后时 warn 并指向 `ocs upgrade`；`OCS_UPGRADE_CHECK=0` 可整体关掉，离线/CI 不受影响。

**`SKILL.md`**：补 Install / upgrade 段；内嵌的 `SKILL_MD` 同步（有逐字节对齐测试守着）。

**版本号 0.4.2 → 0.4.3 随本 PR 同进**：`install.sh` 用 `ocs version` 拼 skill 来源的 tag（`v$version`），tag 与 `OCS_VERSION` 对不上会把 skill 安装搞坏。合并后直接在 main 上打 `v0.4.3`。

## 验证

- 新增 `test/upgrade.test.ts`（10 条）：用 `Bun.serve` 假 GitHub + 写 marker 的假 installer 跑通全路径——落后/一致/领先三态、HTTP 错误/载荷不对/连不上归 unknown、`--check` 不安装、installer 退出码透传、已最新不碰 installer、`--party` 不联网不安装、doctor 落后 warn 与 `OCS_UPGRADE_CHECK=0` 跳过且不联网
- 现有 spawn `doctor` 的用例统一加 `OCS_UPGRADE_CHECK=0` 断网，测试永不碰真 GitHub
- 对真 GitHub 冒烟：本地 0.4.3 vs 最新 v0.4.2 正确判为 ahead；doctor Version 段渲染正常；`--party` 输出原文案
- `bun run check` 154 pass / 0 fail

## 合并后

打 tag `v0.4.3` → release workflow 出三平台二进制 → 在这台 0.4.1 的机器上跑 `ocs upgrade` 做真实端到端。

https://claude.ai/code/session_0152k5peS4FTrFMhCgRkLEVw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `ocs upgrade` now checks for and installs the latest release.
  - Added `--check` for status-only reporting and `--party` for the migration guide.
  - `ocs doctor` now warns when the installed version is outdated.
  - Upgrade checks can be disabled for offline or CI environments.

- **Bug Fixes**
  - Improved Codex connection status reporting on busy machines.

- **Documentation**
  - Added installation and upgrade guidance for the `ocs` skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->