### PR TITLE
feat(codex): 首选官方 `codex queue`，终端里裸跑的 codex 终于可寻址

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ bun src/cli.ts <cmd>   # 本地跑 CLI（who/dm/send/read/notify-when-idle/sessi
 7. 唤醒载荷按 **docs/wake-protocol.md**（与 AgentParty 共用，正本在本仓库）：正文 ≤4096B 逐字内联、超过只带前 512B、整条 ≤5120B，`Reply:`/`Thread:` 两行永不砍。改数字/文案先改协议文档，两边同步。
 8. **notify-when-idle 是一次性的**：watcher 投递一条通知后必须退出；每次翻转都发会把订阅方打成筛子（测试钉着）。
 9. **DM 路由身份是独立 route sidecar，不是 `OcsMessage v1` 字段**：旧二进制会严格拒绝未知消息字段。sidecar 与消息在同一频道 JSONL，必须先写 route、再写 message；这样消息写失败可以安全重试，旧读端仍会跳过 sidecar 并读取原消息。
-10. **Codex rollout ≠ Desktop 可达任务**：`~/.codex/sessions` 只是历史。主动唤醒前必须让 renderer owner claim 目标，并为同 renderer 找到 source；当前 Desktop 对无人认领的 discovery 会超时，候选必须并发短探测，未认领按 `not-open` 停靠 inbox，不当传输故障重试。
+10. **Codex 首选 `codex queue --thread`，Desktop IPC 只是降级**：thread id 就是 rollout 文件名里的 UUID，官方 CLI 按它精确寻址，终端裸跑的 TUI 也能投（不需要 cmux / Desktop / app-server daemon）。但 **`queue` 是写 thread store 不是投递**——目标已退出时照样 exit=0，所以发之前必须用 rollout 文件的 fd 持有者（`lsof`）证明会话活着，查不到就不发（fail closed），欠账留 inbox。走到 Desktop IPC 那一层时旧规则依然成立：必须让 renderer owner claim 目标并为同 renderer 找到 source；Desktop 对无人认领的 discovery 会超时，候选并发短探测，未认领按 `not-open` 停靠 inbox，不当传输故障重试。可达性 = 「有活进程持有 rollout」**或**「被 renderer 认领」——`ocs who` 两者都列，只按后者过滤会把终端里的 codex 整个藏起来。
 
 ## 路线（owner 已拍板）
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -63,9 +63,19 @@
 1. **Claude 侧**：`claude-inbox-inject.ts` — cc-socks Unix socket
    （`/tmp/cc-socks/<pid>.sock`）按 PID 寻址注入活会话，JSONL 帧，
    载荷按 docs/wake-protocol.md：正文 ≤4096B 逐字内联（超过带前 512B），Reply:/Thread: 命令填好。
-2. **Codex 侧**：`codex-desktop-ipc.ts`（#1012）— ChatGPT Desktop 自己的
+2. **Codex 侧（首选）**：`codex-queue.ts` — 官方 CLI 表面 `codex queue --thread <id>
+   --message <text>`。按 thread UUID 精确寻址（thread id 就是 rollout 文件名里的 UUID），
+   **终端里裸跑的 codex TUI 和 Desktop 任务通吃**，不需要 cmux，也不需要目标被 Desktop
+   renderer 认领，更不需要 `codex app-server daemon start`（那条另外要求官方 standalone 安装）。
+   2026-09-07 实测 v0.153.4：往 tmux 里一个纯终端 TUI queue 一条唤醒载荷，TUI 真的跑了那一轮
+   并用 `ocs send` 回了话。
+   **活性必须自己判**：`queue` 是往 thread store 写待处理输入，不是投递——目标已退出时它
+   照样 exit=0 并打印 "Queued message …"。判据取 rollout 文件的 fd 持有者（`lsof`），
+   查不到就不发（fail closed），欠账留给 inbox。
+2b. **Codex 侧（降级）**：`codex-desktop-ipc.ts`（#1012）— ChatGPT Desktop 自己的
    `~/.codex/ipc/ipc.sock`，用 `thread-follower-start-turn` + `codex_app`
-   toolOutput 注入原生跨任务消息，UI 里保留原生来源链接。
+   toolOutput 注入原生跨任务消息，UI 里保留原生来源链接。私有协议，宿主升级可能破，
+   所以只在 `codex queue` 不可用/目标不在跑时才用；再之后才是 cmux 按键注入。
 3. **补充**：Codex Stop hook 的 `{"decision":"block","reason":…}` —
    `reason` 即注入 prompt（≤512B），机制全本地，只有「有没有新消息」一问走服务端。
 4. **Pi 侧**：全局扩展在 `session_start` 登记会话并监听 0600 Unix socket；收到 note 后用
@@ -89,9 +99,9 @@ presence 心跳（本地读 registry 即可）、`worker_upgrade_required` 等�
 ## 四、架构
 
 ```
-┌─ Claude 会话 ─┐  ┌─ Codex/ChatGPT task ─┐  ┌─ Pi TUI ─────┐  ┌─ headless ─────┐
-│ cc-socks UDS  │  │ Desktop IPC          │  │ extension UDS│  │ claude / codex │
-│ 注入          │  │ thread-follower      │  │ followUp     │  │ resume         │
+┌─ Claude 会话 ─┐  ┌─ Codex task/TUI ─────┐  ┌─ Pi TUI ─────┐  ┌─ headless ─────┐
+│ cc-socks UDS  │  │ codex queue（首选）  │  │ extension UDS│  │ claude / codex │
+│ 注入          │  │ → Desktop IPC → cmux │  │ followUp     │  │ resume         │
 └──────┬────────┘  └────────┬─────────────┘  └─────┬────────┘  └──────┬─────────┘
        │                    │                      │                  │
        └────────────── 按目标 harness 选载体 ─────────────────────────┘
@@ -115,7 +125,16 @@ presence 心跳（本地读 registry 即可）、`worker_upgrade_required` 等�
    批准就静默跳过。修复器可复用；绝不用 `--dangerously-bypass-hook-trust`。
 
 **风险**：Desktop IPC 依赖 ChatGPT.app 私有协议，宿主升级会破——需要版本探测 + 降级路径
-（headless spawn 兜底）。
+（headless spawn 兜底）。自 `codex queue` 接入后这条风险降级：私有 IPC 不再是 codex 的
+唯一入口，只是 `codex queue` 之后的第二顺位。
+
+**载体审计结论（2026-09-07）**：另外两条腿**不是绕路**，各自都已经在官方表面上——
+Claude 走的 cc-socks 收件箱就是 Claude Code 自己的跨会话消息通道（原生「Message from X」
+UX + `crossSessionInbound` 权限闸），`claude` CLI 没有等价的发送子命令；Pi 走的是 Pi 官方
+扩展 API，`pi` CLI 根本没有跨会话命令。两条已知的可改进项，都不需要换载体：
+- Claude 侧的「ok ≠ 送达」可以靠订阅 `peer_message_status` 回执收敛（今天只能靠对方回话）。
+- `claude agents --json` 能列出**后台会话**（`kind: "background"`），那是 ocs 今天完全没
+  寻址的一类本机 agent；但 `claude` 也没给后台会话提供发送口，所以是发现有、投递无。
 
 **已知限制（codex-ping 审查 #11）**：Desktop IPC 的 delegation envelope 需要一个
 source thread id，自动选择时它只是**运输载体**（同 renderer 的任一开着任务），不代表

--- a/skills/ocs/SKILL.md
+++ b/skills/ocs/SKILL.md
@@ -36,9 +36,11 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
 - Your own identity is auto-detected inside Claude, Codex, and Pi sessions; `--as <name>` overrides.
 - Codex and Pi tasks have short `codex-<8hex>` / `pi-<8hex>` addresses in `ocs who`;
   use the full ID shown by `ocs who --verbose` only if a short prefix is ambiguous.
-- `ocs who` lists only Codex tasks claimed by an open Desktop renderer.
+- `ocs who` lists every reachable Codex task: one whose rollout is held open by a
+  live process (wakeable with `codex queue`, terminal TUIs included — shown as
+  `[queue pid N]`) or one claimed by an open Desktop renderer (`[desktop]`).
   `ocs codex-sessions` is rollout history and does not imply wakeability.
-  Codex wake also needs a second open task under the same Desktop renderer as
+  The Desktop path additionally needs a second open task under the same renderer as
   the source; `--codex-source` accepts either its full ID or short address.
 - A wake note you receive carries the message body (up to 4096 bytes; longer
   messages show the first 512 bytes plus a Thread: command). Claude-to-Claude DM
@@ -60,11 +62,14 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
   log commit succeeded. Requested wakes report accepted, stored-only, or unknown
   separately. Exit 2 means stored but wake failed; exit 3 means stored with an
   unknown outcome. Never resend either result; inspect the printed channel/seq.
-- If a Codex task is not renderer-open, the message remains stored and will appear
-  in that task's `ocs inbox`; opening/selecting its Desktop task enables direct wake.
-  When Desktop definitely cannot deliver, ocs can fall back to a unique idle cmux
-  surface whose title and live Codex process match that task. It never falls back
-  after an unknown IPC outcome or when the surface match is ambiguous.
+- Codex delivery ladder: `codex queue --thread` first (official CLI, addresses a
+  terminal TUI or a Desktop task alike, no cmux and no Desktop needed), then Desktop
+  IPC, then a cmux surface. ocs only queues to a thread whose rollout has a live
+  process holder, because `codex queue` writes to the thread store and reports
+  success even when nobody is running — queued is not read.
+  If no rung delivers, the message remains stored and appears in that task's
+  `ocs inbox`; opening/selecting its Desktop task enables direct wake. ocs never
+  falls back after an unknown outcome or when a cmux surface match is ambiguous.
 - To keep a conversation going, end your message with the peer's @name so they wake
   (you are never woken by your own @).
 - Replying with `ocs dm <workspace-alias>` reuses the stable or explicitly

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,6 +69,7 @@ import {
   wakeCmuxSurface,
 } from "./roster.ts";
 import { verifiedClaudeWorkspaceIdentity } from "./workspace-registry.ts";
+import { codexQueueAvailable, codexThreadLivePid, queueCodexThread } from "./codex-queue.ts";
 import {
   findSelfClaudePid,
   selectWakeTargets,
@@ -252,6 +253,66 @@ function tryCodexCmuxFallback(
   return true;
 }
 
+/**
+ * codex 目标的统一投递阶梯（消息此前已落盘，这里只负责唤醒）:
+ *   1. `codex queue --thread` —— 官方 CLI 表面，按 thread 精确寻址，终端 TUI / Desktop 通吃，
+ *      不需要 cmux，也不需要目标被 renderer 认领。先用 rollout fd 证明目标活着才发
+ *      （queue 对死会话照样 exit=0，见 codex-queue.ts 的送达语义）。
+ *   2. ChatGPT Desktop IPC —— 私有协议（铁律 5），保留作降级。
+ *   3. cmux 按键注入 —— 最后兜底。
+ * unknown-outcome 在任一层都立即停止：帧可能已写出，绝不重放（铁律 5）。
+ * 返回 false 表示三层都没投出去，调用方按「仅落盘」处理。
+ */
+async function deliverToCodexTask(
+  targetThreadId: string,
+  wakeInput: Omit<WakeNoteInput, "receiver">,
+  sourceThreadId?: string,
+): Promise<boolean> {
+  const livePid = codexThreadLivePid(targetThreadId);
+  if (livePid !== null) {
+    const queued = queueCodexThread({
+      threadId: targetThreadId,
+      livePid,
+      prompt: wakeNote({
+        ...wakeInput,
+        receiver: `codex-${targetThreadId.slice(0, 8)}`,
+        implicitReceiver: true,
+      }),
+    });
+    if (queued.ok) {
+      console.log(M.codexQueued(queued.threadId, queued.pid, queued.messageId));
+      return true;
+    }
+    if (queued.reason === "unknown-outcome") {
+      console.log(M.codexUnknownOutcome(queued.detail ?? ""));
+      markStoredDeliveryFailure("unknown");
+      return true; // 已上报，不再往下投，避免重复送达
+    }
+    console.log(M.codexQueueSkipped(targetThreadId, queued.reason, queued.detail ?? ""));
+  }
+  const result = await wakeCodexTask({
+    targetThreadId,
+    ...(sourceThreadId !== undefined ? { sourceThreadId } : {}),
+    ...wakeInput,
+  });
+  if (result.ok) {
+    console.log(M.codexAccepted(result.targetThreadId, result.turnId));
+    return true;
+  }
+  if (result.reason === "unknown-outcome") {
+    console.log(M.codexUnknownOutcome(result.detail ?? ""));
+    markStoredDeliveryFailure("unknown");
+    return true;
+  }
+  if (tryCodexCmuxFallback(targetThreadId, result.reason, wakeInput)) {
+    // cmux 只复用同一 channel/seq 做唤醒，没有再次落盘。
+    return true;
+  }
+  console.log(M.codexFailed(result.reason, result.detail ?? ""));
+  markStoredDeliveryFailure("failed");
+  return false;
+}
+
 function printMessage(m: { seq: number; ts: string; from: string; body: string }): void {
   console.log(`#${m.seq} ${m.ts} <${m.from}> ${m.body}`);
 }
@@ -360,23 +421,7 @@ async function cmdSend(parsed: Parsed): Promise<void> {
     lang: LANG,
   };
   for (const target of codexTargets) {
-    const result = await wakeCodexTask({
-      targetThreadId: target,
-      ...(codexSource !== undefined ? { sourceThreadId: codexSource } : {}),
-      ...wakeInput,
-    });
-    if (result.ok) {
-      console.log(M.codexAccepted(result.targetThreadId, result.turnId));
-    } else if (result.reason === "unknown-outcome") {
-      // 上游铁律：帧已写出但结果未知——如实报告、绝不重放
-      console.log(M.codexUnknownOutcome(result.detail ?? ""));
-      markStoredDeliveryFailure("unknown");
-    } else if (tryCodexCmuxFallback(target, result.reason, wakeInput)) {
-      // cmux 只复用同一 channel/seq 做唤醒，没有再次落盘。
-    } else {
-      console.log(M.codexFailed(result.reason, result.detail ?? ""));
-      markStoredDeliveryFailure("failed");
-    }
+    await deliverToCodexTask(target, wakeInput, codexSource);
   }
 
   // Pi 侧：全局扩展登记活 TUI，并经私有 UDS 收件箱注入。忙碌时由 Pi 自己排成 follow-up。
@@ -584,17 +629,7 @@ async function cmdDm(parsed: Parsed): Promise<void> {
     }
     if (idleSubscriber !== null) subscribeIdle(idleSubscriber, [resolved.claude]);
   } else if (resolved.kind === "codex-task" && resolved.threadId !== undefined) {
-    const result = await wakeCodexTask({ targetThreadId: resolved.threadId, ...wakeInput });
-    if (result.ok) console.log(M.codexAccepted(result.targetThreadId, result.turnId));
-    else if (result.reason === "unknown-outcome") {
-      console.log(M.codexUnknownOutcome(result.detail ?? ""));
-      markStoredDeliveryFailure("unknown");
-    } else if (tryCodexCmuxFallback(resolved.threadId, result.reason, wakeInput)) {
-      // cmux 只复用同一 channel/seq 做唤醒，没有再次落盘。
-    } else {
-      console.log(M.codexFailed(result.reason, result.detail ?? ""));
-      markStoredDeliveryFailure("failed");
-    }
+    await deliverToCodexTask(resolved.threadId, wakeInput);
     if (idleSubscriber !== null) subscribeIdle(idleSubscriber, []);
   } else if (resolved.kind === "pi" && resolved.piSessionId !== undefined) {
     if (resolved.piSession === undefined) {
@@ -701,7 +736,10 @@ async function cmdWho(parsed: Parsed): Promise<void> {
       // Socket/router failure is reported below as no verified open tasks.
     }
   }
-  const codex = codexCandidates.filter((entry) => codexOwners[entry.threadId] !== undefined);
+  // 可达 = Desktop renderer 认领（IPC 可投）或 rollout fd 有活进程（`codex queue` 可投）。
+  // 只按前者过滤会把终端里裸跑的 codex 整个藏起来——那正是用户报的「cc 发现不了终端里的 codex」。
+  const codex = codexCandidates.filter((entry) =>
+    entry.kind === "codex-task" && (codexOwners[entry.threadId] !== undefined || entry.livePid !== null));
   const pi = relevantFirst(roster.entries.filter((e) => e.kind === "pi"));
   const cmux = roster.entries.filter((e) => e.kind === "cmux");
   if (json) {
@@ -724,10 +762,12 @@ async function cmdWho(parsed: Parsed): Promise<void> {
     for (const e of codex) {
       if (e.kind !== "codex-task") continue;
       const label = e.summary ?? (e.cwd === null ? "" : basename(e.cwd));
+      // 载体标注：queue 走官方 CLI（终端 TUI 也吃），desktop 是私有 IPC 降级路径。
+      const via = e.livePid === null ? M.whoCodexViaDesktop : M.whoCodexViaQueue(e.livePid);
       console.log(
         verbose
-          ? `  ${e.target}  thread=${e.threadId}  cwd=${e.cwd ?? "?"}${projectTag(e)}${e.self ? M.whoSelfTag : ""}`
-          : `  ${e.target}  ${label.slice(0, 60)}${projectTag(e)}${e.self ? M.whoSelfTag : ""}`,
+          ? `  ${e.target}  thread=${e.threadId}  cwd=${e.cwd ?? "?"}  ${via}${projectTag(e)}${e.self ? M.whoSelfTag : ""}`
+          : `  ${e.target}  ${label.slice(0, 60)}  ${via}${projectTag(e)}${e.self ? M.whoSelfTag : ""}`,
       );
     }
   } else if (codexCandidates.length > 0) {
@@ -924,6 +964,10 @@ async function cmdDoctor(parsed: Parsed): Promise<void> {
   }
 
   console.log(M.doctorCodex);
+  // 首选载体先报：`codex queue` 是官方 CLI 表面，终端 TUI 和 Desktop 任务都能投；
+  // Desktop IPC 是私有协议降级路径，它不可用不再等于「codex 不可达」。
+  if (codexQueueAvailable()) ok(M.doctorCodexQueueOk);
+  else warn(M.doctorCodexQueueMissing);
   const ipcAvailable = codexDesktopIpcAvailable();
   if (ipcAvailable) {
     ok(M.doctorIpcOk(codexDesktopIpcSocketPath()));
@@ -1049,9 +1093,11 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
 - Your own identity is auto-detected inside Claude, Codex, and Pi sessions; \`--as <name>\` overrides.
 - Codex and Pi tasks have short \`codex-<8hex>\` / \`pi-<8hex>\` addresses in \`ocs who\`;
   use the full ID shown by \`ocs who --verbose\` only if a short prefix is ambiguous.
-- \`ocs who\` lists only Codex tasks claimed by an open Desktop renderer.
+- \`ocs who\` lists every reachable Codex task: one whose rollout is held open by a
+  live process (wakeable with \`codex queue\`, terminal TUIs included — shown as
+  \`[queue pid N]\`) or one claimed by an open Desktop renderer (\`[desktop]\`).
   \`ocs codex-sessions\` is rollout history and does not imply wakeability.
-  Codex wake also needs a second open task under the same Desktop renderer as
+  The Desktop path additionally needs a second open task under the same renderer as
   the source; \`--codex-source\` accepts either its full ID or short address.
 - A wake note you receive carries the message body (up to 4096 bytes; longer
   messages show the first 512 bytes plus a Thread: command). Claude-to-Claude DM
@@ -1073,11 +1119,14 @@ ocs whoami | sessions | watch <channel> | doctor [--fix] | version
   log commit succeeded. Requested wakes report accepted, stored-only, or unknown
   separately. Exit 2 means stored but wake failed; exit 3 means stored with an
   unknown outcome. Never resend either result; inspect the printed channel/seq.
-- If a Codex task is not renderer-open, the message remains stored and will appear
-  in that task's \`ocs inbox\`; opening/selecting its Desktop task enables direct wake.
-  When Desktop definitely cannot deliver, ocs can fall back to a unique idle cmux
-  surface whose title and live Codex process match that task. It never falls back
-  after an unknown IPC outcome or when the surface match is ambiguous.
+- Codex delivery ladder: \`codex queue --thread\` first (official CLI, addresses a
+  terminal TUI or a Desktop task alike, no cmux and no Desktop needed), then Desktop
+  IPC, then a cmux surface. ocs only queues to a thread whose rollout has a live
+  process holder, because \`codex queue\` writes to the thread store and reports
+  success even when nobody is running — queued is not read.
+  If no rung delivers, the message remains stored and appears in that task's
+  \`ocs inbox\`; opening/selecting its Desktop task enables direct wake. ocs never
+  falls back after an unknown outcome or when a cmux surface match is ambiguous.
 - To keep a conversation going, end your message with the peer's @name so they wake
   (you are never woken by your own @).
 - Replying with \`ocs dm <workspace-alias>\` reuses the stable or explicitly

--- a/src/codex-queue.ts
+++ b/src/codex-queue.ts
@@ -1,0 +1,202 @@
+// Codex 官方跨会话通道：`codex queue --thread <id> --message <text>`。
+//
+// 为什么这条路优先于 ChatGPT Desktop IPC 和 cmux 按键注入：
+//   * `codex queue` 是公开的 CLI 表面，按 thread UUID 精确寻址，不碰终端、不模拟按键，
+//     也不要求目标被 Desktop renderer 认领——终端里裸跑的 codex TUI 一样能收到。
+//   * Desktop IPC（codex-ipc.ts）是 ChatGPT.app 的私有协议（铁律 5），宿主升级可能破；
+//     cmux 注入要求用户装 cmux，且靠 `codex-<8hex>` 标题正则匹配，都是绕路。
+// 实测（v0.153.4）：往 tmux 里一个纯终端 codex TUI queue 一条消息，TUI 真的跑了那一轮。
+// 不需要 `codex app-server daemon start`（那条命令另外要求官方 standalone 安装）。
+//
+// 送达语义 —— 与铁律 4（Claude 注入 ok ≠ 已送达）同构，而且更严格:
+//   `codex queue` 是往 thread store 写待处理输入，**不是投递**。目标会话已经退出时它
+//   照样 exit=0 并打印 "Queued message …"。所以活性判断必须由我们自己做，绝不能拿
+//   queue 的退出码清欠账。活性证据取 rollout 文件的持有者：活着的 codex 进程一直
+//   打开着自己的 rollout，`lsof -t <rollout>` 拿到 pid 即为在跑（终端/Desktop 通用，
+//   比标题匹配和 renderer 认领都硬）。
+//
+// 超时/信号杀死一律记 unknown-outcome：帧可能已写进 store（铁律 5，绝不重放）。
+
+import { spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { isCodexThreadId, listCodexRolloutFiles, codexSessionsRoot } from "./codex-sessions.ts";
+
+/** `codex --version` 探测预算。 */
+export const CODEX_CLI_PROBE_TIMEOUT_MS = 3000;
+/** `codex queue` 预算：要连 thread store，比纯探测宽。 */
+export const CODEX_QUEUE_TIMEOUT_MS = 20_000;
+/** `lsof` 预算：单文件查询，很快；卡住就当查不到（fail closed）。 */
+export const CODEX_LSOF_TIMEOUT_MS = 4000;
+
+export type CodexQueueResult =
+  | { ok: true; messageId: string | null; threadId: string; pid: number }
+  | {
+      ok: false;
+      reason: "unavailable" | "bad-thread-id" | "not-live" | "failed" | "unknown-outcome";
+      detail?: string;
+    };
+
+let cliProbeCache: boolean | null = null;
+
+/** 测试用：清掉 `codex` CLI 可用性缓存。 */
+export function resetCodexCliProbeCache(): void {
+  cliProbeCache = null;
+}
+
+/**
+ * 本机有没有可用的 `codex` CLI。只探一次并缓存——send 路径上每个 codex 目标都会问。
+ * 探 `queue --help` 而不是 `--version`：老版本有 codex 但没有 queue 子命令，我们要的是
+ * 「这条通道在不在」，不是「codex 在不在」。
+ */
+export function codexQueueAvailable(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (cliProbeCache !== null) return cliProbeCache;
+  const probe = spawnSync("codex", ["queue", "--help"], {
+    encoding: "utf8",
+    timeout: CODEX_CLI_PROBE_TIMEOUT_MS,
+    env,
+  });
+  cliProbeCache = probe.status === 0 && (probe.stdout ?? "").includes("--thread");
+  return cliProbeCache;
+}
+
+/** 该 thread 的 rollout 文件路径（thread id 就是 rollout 文件名里的 UUID）。 */
+export function codexRolloutPath(
+  threadId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  if (!isCodexThreadId(threadId)) return null;
+  const wanted = threadId.toLowerCase();
+  return listCodexRolloutFiles(codexSessionsRoot(env))
+    .find((file) => file.threadId === wanted)?.path ?? null;
+}
+
+/**
+ * 活性证据：拿着这个 thread 的 rollout 文件的进程 pid。
+ * 活着的 codex 会话（终端 TUI 或 Desktop 任务）全程持有自己的 rollout fd；会话退出后
+ * 没人持有。查不到就是查不到——宁可判死也不要往死会话投递（fail closed）。
+ */
+export function codexThreadLivePid(
+  threadId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): number | null {
+  const path = codexRolloutPath(threadId, env);
+  if (path === null) return null;
+  const probe = spawnSync("lsof", ["-t", "--", realpathOrSelf(path)], {
+    encoding: "utf8",
+    timeout: CODEX_LSOF_TIMEOUT_MS,
+    env: lsofEnv(env),
+  });
+  // lsof 没命中时 status=1 且无输出，这是正常的「不在跑」，不是错误。
+  const pid = Number((probe.stdout ?? "").split("\n").map((l) => l.trim()).find((l) => l !== ""));
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+/**
+ * 批量版活性探测：一次 lsof 查多个 thread，给 `ocs who` 用（逐个 spawn 会把 who 拖慢）。
+ * `lsof -F pn` 逐文件输出 `p<pid>` / `n<path>`；部分文件无人持有时 lsof 退 1，这是正常
+ * 结果不是错误，只按输出解析。
+ */
+export function codexThreadLivePids(
+  threadIds: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Map<string, number> {
+  const live = new Map<string, number>();
+  const byPath = new Map<string, string>();
+  for (const id of threadIds) {
+    const path = codexRolloutPath(id, env);
+    // lsof 报的是解析过符号链接的真实路径（macOS 的 /var/folders → /private/var/folders），
+    // 按原始路径匹配会全部落空。
+    if (path !== null) byPath.set(realpathOrSelf(path), id.toLowerCase());
+  }
+  if (byPath.size === 0) return live;
+  const probe = spawnSync("lsof", ["-F", "pn", "--", ...byPath.keys()], {
+    encoding: "utf8",
+    timeout: CODEX_LSOF_TIMEOUT_MS,
+    env: lsofEnv(env),
+  });
+  let pid: number | null = null;
+  for (const line of (probe.stdout ?? "").split("\n")) {
+    if (line.startsWith("p")) {
+      const parsed = Number(line.slice(1));
+      pid = Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    } else if (line.startsWith("n") && pid !== null) {
+      const id = byPath.get(line.slice(1));
+      if (id !== undefined && !live.has(id)) live.set(id, pid);
+    }
+  }
+  return live;
+}
+
+/**
+ * lsof 是系统工具，跟 `codex` CLI 在不在 PATH 上无关：调用方传进来的 env 可能是只带
+ * CODEX_HOME 的最小环境，用它去找 lsof 会 ENOENT。这里固定用进程自己的 PATH。
+ */
+function lsofEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return { ...env, PATH: process.env.PATH ?? "/usr/sbin:/usr/bin:/bin" };
+}
+
+function realpathOrSelf(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+const QUEUED_ID_RE = /Queued message ([0-9a-f-]{36})/i;
+
+/**
+ * 把一条唤醒载荷 queue 给指定 thread。
+ * 只在确认目标活着之后才真的发（见文件头「送达语义」）；`livePid` 可由调用方传入以
+ * 复用已经做过的活性探测，省一次 lsof。
+ */
+export function queueCodexThread(input: {
+  threadId: string;
+  prompt: string;
+  env?: NodeJS.ProcessEnv;
+  /** 已知的活进程 pid；不传则现场探测。 */
+  livePid?: number;
+}): CodexQueueResult {
+  const env = input.env ?? process.env;
+  const threadId = input.threadId.toLowerCase();
+  if (!isCodexThreadId(threadId)) return { ok: false, reason: "bad-thread-id", detail: input.threadId };
+  if (!codexQueueAvailable(env)) {
+    return {
+      ok: false,
+      reason: "unavailable",
+      detail: "`codex queue` unavailable (no codex CLI on PATH, or too old to have the subcommand)",
+    };
+  }
+  const pid = input.livePid ?? codexThreadLivePid(threadId, env);
+  if (pid === null) {
+    return {
+      ok: false,
+      reason: "not-live",
+      detail:
+        `no live process holds the rollout for thread ${threadId}; ` +
+        `\`codex queue\` would write to the thread store with nobody to read it`,
+    };
+  }
+  const proc = spawnSync("codex", ["queue", "--thread", threadId, "--message", input.prompt], {
+    encoding: "utf8",
+    timeout: CODEX_QUEUE_TIMEOUT_MS,
+    env,
+  });
+  // 超时/被信号杀死：帧可能已经写进 thread store，结果未知——如实上报，绝不重放。
+  if (proc.error !== undefined || proc.signal !== null) {
+    return {
+      ok: false,
+      reason: "unknown-outcome",
+      detail: `codex queue did not report an outcome (${proc.signal ?? String(proc.error)})`,
+    };
+  }
+  if (proc.status !== 0) {
+    return {
+      ok: false,
+      reason: "failed",
+      detail: (proc.stderr ?? proc.stdout ?? "").trim() || `codex queue exited ${proc.status}`,
+    };
+  }
+  const messageId = QUEUED_ID_RE.exec(proc.stdout ?? "")?.[1] ?? null;
+  return { ok: true, messageId, threadId, pid };
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -39,6 +39,8 @@ interface Catalog {
   codexUnknownOutcome: (detail: string) => string;
   codexFailed: (reason: string, detail: string) => string;
   codexCmuxFallback: (thread: string, reason: string, ref: string) => string;
+  codexQueued: (thread: string, pid: number, messageId: string | null) => string;
+  codexQueueSkipped: (thread: string, reason: string, detail: string) => string;
   piWakeAccepted: (target: string) => string;
   piWakeUnknownOutcome: (target: string, detail: string) => string;
   piWakeFailed: (target: string, reason: string, detail: string) => string;
@@ -66,6 +68,8 @@ interface Catalog {
   doctorSkillsFixed: string;
   doctorSkillsFixFailed: (detail: string) => string;
   doctorCodex: string;
+  doctorCodexQueueOk: string;
+  doctorCodexQueueMissing: string;
   doctorIpcOk: (path: string) => string;
   doctorIpcMissing: (path: string) => string;
   doctorIpcRouteOk: string;
@@ -118,6 +122,8 @@ interface Catalog {
   whoClaudeHeader: string;
   whoCodexHeader: (ipc: boolean) => string;
   whoCodexNone: (ipc: boolean) => string;
+  whoCodexViaQueue: (pid: number) => string;
+  whoCodexViaDesktop: string;
   whoPiHeader: string;
   whoCmuxHeader: string;
   whoSelfTag: string;
@@ -239,6 +245,11 @@ Data directory: ~/.ocs (override with OCS_HOME). Language: OCS_LANG=en|zh.`,
     `wake(codex): stored-only (${reason})${detail ? `: ${detail}` : ""} (message is already stored; do not resend)`,
   codexCmuxFallback: (thread, reason, ref) =>
     `wake(codex): Desktop ${reason} for ${thread}; woke terminal ${ref} via cmux fallback`,
+  codexQueued: (thread, pid, messageId) =>
+    `wake(codex): queued → task ${thread} via \`codex queue\` (live pid ${pid}` +
+    `${messageId === null ? "" : `, message ${messageId}`}) — queued, not confirmed read`,
+  codexQueueSkipped: (thread, reason, detail) =>
+    `wake(codex): \`codex queue\` skipped for ${thread} (${reason})${detail ? `: ${detail}` : ""}; trying Desktop IPC`,
   piWakeAccepted: (target) => `wake(pi): queued → ${target}`,
   piWakeUnknownOutcome: (target, detail) =>
     `wake(pi): outcome unknown for ${target} (frame was written — do NOT resend)${detail ? `: ${detail}` : ""}`,
@@ -275,7 +286,11 @@ Data directory: ~/.ocs (override with OCS_HOME). Language: OCS_LANG=en|zh.`,
     `${n} agent skill installation(s) missing or outdated — run \`ocs doctor --fix\``,
   doctorSkillsFixed: "updated the ocs skill for Claude, Codex, and Pi",
   doctorSkillsFixFailed: (detail) => `integration repair failed: ${detail}`,
-  doctorCodex: "Codex / ChatGPT Desktop side",
+  doctorCodex: "Codex side (`codex queue` preferred; Desktop IPC is the fallback)",
+  doctorCodexQueueOk:
+    "`codex queue` available — terminal Codex TUIs are wakeable without cmux or ChatGPT Desktop",
+  doctorCodexQueueMissing:
+    "`codex queue` unavailable (no codex CLI on PATH, or too old): only ChatGPT Desktop IPC / cmux remain",
   doctorIpcOk: (path) => `Desktop IPC router socket available (${path})`,
   doctorIpcMissing: (path) => `Desktop IPC unavailable (${path} missing or wrong perms) — is ChatGPT Desktop running?`,
   doctorIpcRouteOk: "this Codex task is claimed by an open Desktop renderer (wakeable)",
@@ -336,10 +351,12 @@ Local ocs and hosted party coexist fine: same-machine work stays on ocs, cross-m
   failLimit: "--limit must be a positive integer",
   whoClaudeHeader: "Claude Code sessions (wake: @name / ocs dm <name>)",
   whoCodexHeader: (_ipc) =>
-    "Open Codex tasks (wake: ocs dm codex-<short-id>; renderer ownership verified)",
+    "Reachable Codex tasks (wake: ocs dm codex-<short-id>; terminal TUIs included)",
   whoCodexNone: (ipc) => ipc
-    ? "Codex: no recent rollout is currently claimed by an open Desktop renderer (\`ocs codex-sessions\` shows history)"
-    : "Codex: Desktop IPC socket unavailable — open ChatGPT Desktop",
+    ? "Codex: no recent rollout is live or claimed by an open Desktop renderer (\`ocs codex-sessions\` shows history)"
+    : "Codex: no live rollout, and the Desktop IPC socket is unavailable — start a codex session or open ChatGPT Desktop",
+  whoCodexViaQueue: (pid) => `[queue pid ${pid}]`,
+  whoCodexViaDesktop: "[desktop]",
   whoPiHeader: "Pi sessions (wake: ocs dm pi-<short-id>; @ mentions use the full session id)",
   whoCmuxHeader: "cmux terminal surfaces (wake: ocs dm surface:N)",
   whoSelfTag: "  ← you",
@@ -467,6 +484,11 @@ const zh: Catalog = {
     `wake(codex): 仅落盘（${reason}）${detail ? `: ${detail}` : ""}（消息已经落盘，请勿重发）`,
   codexCmuxFallback: (thread, reason, ref) =>
     `wake(codex): Desktop 对 ${thread} 返回 ${reason}；已自动降级由 cmux 唤醒终端 ${ref}`,
+  codexQueued: (thread, pid, messageId) =>
+    `wake(codex): 已 queue → task ${thread}（\`codex queue\`，活进程 pid ${pid}` +
+    `${messageId === null ? "" : `，message ${messageId}`}）——已入队，未确认读取`,
+  codexQueueSkipped: (thread, reason, detail) =>
+    `wake(codex): ${thread} 跳过 \`codex queue\`（${reason}）${detail ? `: ${detail}` : ""}；改试 Desktop IPC`,
   piWakeAccepted: (target) => `wake(pi): 已排队 → ${target}`,
   piWakeUnknownOutcome: (target, detail) =>
     `wake(pi): ${target} 结果未知（帧已写出，勿重发）${detail ? `: ${detail}` : ""}`,
@@ -502,7 +524,11 @@ const zh: Catalog = {
   doctorSkillsMissing: (n) => `${n} 处 agent skill 缺失或版本过旧——运行 \`ocs doctor --fix\``,
   doctorSkillsFixed: "已更新 Claude、Codex、Pi 的 ocs skill",
   doctorSkillsFixFailed: (detail) => `集成修复失败：${detail}`,
-  doctorCodex: "Codex / ChatGPT Desktop 侧",
+  doctorCodex: "Codex 侧（首选 `codex queue`，Desktop IPC 为降级）",
+  doctorCodexQueueOk:
+    "`codex queue` 可用——终端里的 Codex TUI 无需 cmux、无需 ChatGPT Desktop 即可唤醒",
+  doctorCodexQueueMissing:
+    "`codex queue` 不可用（PATH 上没有 codex，或版本过旧）：只剩 ChatGPT Desktop IPC / cmux",
   doctorIpcOk: (path) => `Desktop IPC 路由 socket 存在（${path}）`,
   doctorIpcMissing: (path) => `Desktop IPC 不可用（${path} 缺失或权限不对）——ChatGPT Desktop 开着吗？`,
   doctorIpcRouteOk: "当前 Codex task 已被打开的 Desktop renderer 认领（可唤醒）",
@@ -561,10 +587,12 @@ const zh: Catalog = {
   failLimit: "--limit 必须是正整数",
   whoClaudeHeader: "Claude Code 会话（唤醒: @名字 / ocs dm <名字>）",
   whoCodexHeader: (_ipc) =>
-    "已打开的 Codex task（唤醒: ocs dm codex-<短id>；renderer ownership 已验证）",
+    "可达的 Codex task（唤醒: ocs dm codex-<短id>；终端里的 TUI 也在内）",
   whoCodexNone: (ipc) => ipc
-    ? "Codex：近期 rollout 当前都没有被打开的 Desktop renderer 认领（\`ocs codex-sessions\` 可看历史）"
-    : "Codex：Desktop IPC socket 不可用——请打开 ChatGPT Desktop",
+    ? "Codex：近期 rollout 既没有活进程，也没有被打开的 Desktop renderer 认领（\`ocs codex-sessions\` 可看历史）"
+    : "Codex：没有活着的 rollout，Desktop IPC socket 也不可用——起一个 codex 会话或打开 ChatGPT Desktop",
+  whoCodexViaQueue: (pid) => `[queue pid ${pid}]`,
+  whoCodexViaDesktop: "[desktop]",
   whoPiHeader: "Pi 会话（唤醒: ocs dm pi-<短id>；@ 提及仍使用完整 session id）",
   whoCmuxHeader: "cmux 终端 surface（唤醒: ocs dm surface:N）",
   whoSelfTag: "  ← 你自己",

--- a/src/roster.ts
+++ b/src/roster.ts
@@ -16,6 +16,7 @@ import {
 } from "./claude-address.ts";
 import { listNativeSessions, type NativeClaudeSession } from "./claude-inject.ts";
 import { codexDesktopIpcAvailable } from "./codex-ipc.ts";
+import { codexThreadLivePids } from "./codex-queue.ts";
 import {
   codexSessionsRoot,
   isCodexThreadId,
@@ -264,6 +265,8 @@ export type RosterEntry =
       summary: string | null;
       cwd: string | null;
       self: boolean;
+      /** 持有该 thread rollout fd 的进程；非 null 即证明会话在跑（`codex queue` 可达）。 */
+      livePid: number | null;
     }
   | {
       kind: "pi";
@@ -314,7 +317,10 @@ export function buildRoster(env: NodeJS.ProcessEnv = process.env): Roster {
   const selfCodexThreadId = isCodexThreadId(env[CODEX_THREAD_ID_ENV] ?? "")
     ? env[CODEX_THREAD_ID_ENV]!.toLowerCase()
     : null;
-  for (const s of listCodexSessions(codexSessionsRoot(env), { limit: 10 })) {
+  const codexSessions = listCodexSessions(codexSessionsRoot(env), { limit: 10 });
+  // 一次 lsof 批量判活：rollout fd 的持有者证明会话在跑，终端 TUI 和 Desktop 任务通用。
+  const codexLive = codexThreadLivePids(codexSessions.map((s) => s.threadId), env);
+  for (const s of codexSessions) {
     entries.push({
       kind: "codex-task",
       target: `codex-${s.threadId.slice(0, 8)}`,
@@ -322,6 +328,7 @@ export function buildRoster(env: NodeJS.ProcessEnv = process.env): Roster {
       summary: s.summary,
       cwd: s.cwd,
       self: s.threadId === selfCodexThreadId,
+      livePid: codexLive.get(s.threadId) ?? null,
     });
   }
   const selfPiSessionId = env[OCS_PI_SESSION_ID_ENV]?.toLowerCase();

--- a/test/codex-queue.test.ts
+++ b/test/codex-queue.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { closeSync, mkdirSync, openSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  codexQueueAvailable,
+  codexRolloutPath,
+  codexThreadLivePid,
+  codexThreadLivePids,
+  queueCodexThread,
+  resetCodexCliProbeCache,
+} from "../src/codex-queue.ts";
+import { autoCleanupTempDirs, tempDir } from "./tmp";
+
+autoCleanupTempDirs();
+
+const THREAD_LIVE = "11111111-1111-2222-3333-444444444444";
+const THREAD_DEAD = "22222222-1111-2222-3333-444444444444";
+const UNKNOWN = "33333333-1111-2222-3333-444444444444";
+
+/** 两个 rollout：调用方自己决定给哪个开 fd（开着的那个就是「活会话」）。 */
+function rolloutFixture(): { env: NodeJS.ProcessEnv; live: string; dead: string } {
+  const codexHome = tempDir("ocs-codexq-");
+  const day = join(codexHome, "sessions", "2026", "09", "07");
+  mkdirSync(day, { recursive: true });
+  const live = join(day, `rollout-2026-09-07T10-00-00-${THREAD_LIVE}.jsonl`);
+  const dead = join(day, `rollout-2026-09-07T09-00-00-${THREAD_DEAD}.jsonl`);
+  writeFileSync(live, "");
+  writeFileSync(dead, "");
+  return { env: { CODEX_HOME: codexHome }, live, dead };
+}
+
+/** 假的 `codex`：记录收到的参数，永远成功。 */
+function fakeCodexBin(options: { queueSupported?: boolean } = {}): {
+  env: NodeJS.ProcessEnv;
+  argsLog: string;
+} {
+  const bin = tempDir("ocs-codexbin-");
+  const argsLog = join(bin, "args.log");
+  const help = options.queueSupported === false
+    ? "Usage: codex queue"
+    : "Usage: codex queue [OPTIONS] --thread <THREAD> --message <TEXT>";
+  writeFileSync(
+    join(bin, "codex"),
+    `#!/bin/sh
+if [ "$1" = "queue" ] && [ "$2" = "--help" ]; then printf '%s\\n' ${JSON.stringify(help)}; exit 0; fi
+printf '%s\\n' "$*" >> ${JSON.stringify(argsLog)}
+echo "Queued message 01a079c9-7318-7192-ae2c-8078515ad91a for thread $3."
+`,
+    { mode: 0o755 },
+  );
+  resetCodexCliProbeCache();
+  return { env: { PATH: `${bin}:/usr/bin:/bin` }, argsLog };
+}
+
+describe("codex-queue：thread → rollout 路径", () => {
+  test("按 thread id 找到 rollout；未知 thread 与非法 id 都是 null", () => {
+    const { env, live } = rolloutFixture();
+    expect(codexRolloutPath(THREAD_LIVE, env)).toBe(live);
+    expect(codexRolloutPath(UNKNOWN, env)).toBeNull();
+    expect(codexRolloutPath("not-a-uuid", env)).toBeNull();
+  });
+});
+
+describe("codex-queue：活性判定（rollout fd 持有者）", () => {
+  test("有人持有 rollout fd 即为活；无人持有为死", () => {
+    const { env, live } = rolloutFixture();
+    const fd = openSync(live, "r");
+    try {
+      // 本测试进程自己持有 fd，所以 lsof 报出来的就是我们自己的 pid。
+      expect(codexThreadLivePid(THREAD_LIVE, env)).toBe(process.pid);
+      expect(codexThreadLivePid(THREAD_DEAD, env)).toBeNull();
+    } finally {
+      closeSync(fd);
+    }
+    expect(codexThreadLivePid(THREAD_LIVE, env)).toBeNull();
+  });
+
+  test("批量探测只认真正被持有的那个（部分未命中时 lsof 退 1，不算失败）", () => {
+    const { env, live } = rolloutFixture();
+    const fd = openSync(live, "r");
+    try {
+      const live_ = codexThreadLivePids([THREAD_LIVE, THREAD_DEAD, UNKNOWN], env);
+      expect(live_.get(THREAD_LIVE)).toBe(process.pid);
+      expect(live_.has(THREAD_DEAD)).toBe(false);
+      expect(live_.has(UNKNOWN)).toBe(false);
+    } finally {
+      closeSync(fd);
+    }
+  });
+});
+
+describe("codex-queue：投递", () => {
+  test("目标活着时才真的 queue，参数按 --thread/--message 传", () => {
+    const rollout = rolloutFixture();
+    const bin = fakeCodexBin();
+    const env = { ...rollout.env, ...bin.env };
+    const fd = openSync(rollout.live, "r");
+    try {
+      const result = queueCodexThread({ threadId: THREAD_LIVE, prompt: "hello", env });
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("unreachable");
+      expect(result.threadId).toBe(THREAD_LIVE);
+      expect(result.pid).toBe(process.pid);
+      expect(result.messageId).toBe("01a079c9-7318-7192-ae2c-8078515ad91a");
+    } finally {
+      closeSync(fd);
+    }
+    expect(Bun.file(bin.argsLog).text()).resolves.toContain(
+      `queue --thread ${THREAD_LIVE} --message hello`,
+    );
+  });
+
+  test("目标不在跑就绝不 queue：queue 是写 thread store，对死会话照样成功", async () => {
+    const rollout = rolloutFixture();
+    const bin = fakeCodexBin();
+    const result = queueCodexThread({
+      threadId: THREAD_DEAD,
+      prompt: "hello",
+      env: { ...rollout.env, ...bin.env },
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toBe("not-live");
+    // 关键：一个字都没发出去，欠账留给 inbox。
+    expect(await Bun.file(bin.argsLog).exists()).toBe(false);
+  });
+
+  test("非法 thread id 直接拒绝，不 spawn", async () => {
+    const bin = fakeCodexBin();
+    const result = queueCodexThread({ threadId: "nope", prompt: "x", env: bin.env });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toBe("bad-thread-id");
+    expect(await Bun.file(bin.argsLog).exists()).toBe(false);
+  });
+
+  test("PATH 上没有 codex 时报 unavailable，不静默当成功", () => {
+    resetCodexCliProbeCache();
+    const rollout = rolloutFixture();
+    const empty = tempDir("ocs-nobin-");
+    const result = queueCodexThread({
+      threadId: THREAD_LIVE,
+      prompt: "x",
+      env: { ...rollout.env, PATH: empty },
+      livePid: process.pid,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toBe("unavailable");
+    resetCodexCliProbeCache();
+  });
+
+  test("codex 太老、queue 没有 --thread 时视为通道不存在", () => {
+    const bin = fakeCodexBin({ queueSupported: false });
+    expect(codexQueueAvailable(bin.env)).toBe(false);
+    resetCodexCliProbeCache();
+  });
+});

--- a/test/codex.test.ts
+++ b/test/codex.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, closeSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -208,7 +208,7 @@ async function runCli(
 }
 
 describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
-  test("ocs who 只展示被 open renderer 认领的 Codex task", async () => {
+  test("ocs who 展示被 open renderer 认领的 Codex task（无人持有 rollout 时 livePid 为 null）", async () => {
     const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_A]) });
     try {
       const result = await runCli(router, ["who", "--json"], { CODEX_THREAD_ID: THREAD_B });
@@ -221,6 +221,7 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
           summary?: string | null;
           cwd?: string | null;
           self?: boolean;
+          livePid?: number | null;
         }>;
       };
       const codex = roster.entries.filter((entry) => entry.kind === "codex-task");
@@ -231,8 +232,35 @@ describe("wakeCodexTask 端到端（假 IPC 路由器）", () => {
         summary: "hello world",
         cwd: "/tmp/b",
         self: true,
+        livePid: null,
       }]);
     } finally {
+      router.close();
+    }
+  }, T);
+
+  // 用户报的 bug：终端里裸跑的 codex 完全不出现在 who 里，因为过滤条件只认 Desktop
+  // renderer 认领。可达性现在等于「认领 或 rollout 有活进程」——后者是 `codex queue`
+  // 的投递条件，也是终端 TUI 唯一的存在证明。
+  test("ocs who 展示未被 renderer 认领但活着的 Codex task（终端 TUI）", async () => {
+    const router = fakeRouter({ ignoreOwnerFor: new Set([THREAD_A, THREAD_B]) });
+    const rollout = join(
+      router.env.CODEX_HOME!,
+      "sessions", "2026", "08", "31",
+      `rollout-2026-08-31T10-00-00-${THREAD_A}.jsonl`,
+    );
+    const fd = openSync(rollout, "r"); // 本测试进程冒充活着的 codex 会话
+    try {
+      const result = await runCli(router, ["who", "--json"]);
+      expect(result.code).toBe(0);
+      const roster = JSON.parse(result.stdout) as {
+        entries: Array<{ kind: string; threadId?: string; livePid?: number | null }>;
+      };
+      const codex = roster.entries.filter((entry) => entry.kind === "codex-task");
+      expect(codex.map((entry) => entry.threadId)).toEqual([THREAD_A]);
+      expect(codex[0]!.livePid).toBe(process.pid);
+    } finally {
+      closeSync(fd);
       router.close();
     }
   }, T);


### PR DESCRIPTION
## 起因

群里报的问题：**cc 发现不了旁边终端里开着的 codex，非要去 Codex Desktop 里找。**

根因是 codex 这条腿一直绕路——只有两条投递路径：ChatGPT Desktop 私有 IPC（要求目标被 renderer 认领）和 cmux 按键注入（要求装 cmux）。没有 cmux 时，终端里的 codex 既投不进去，`ocs who` 里也**整个不显示**（过滤条件只认 renderer 认领）。

而 codex CLI 自己早就有跨会话表面：`codex queue --thread <uuid> --message <text>`，按 thread UUID 精确寻址，thread id 就是 rollout 文件名里那个 UUID。

## 改动

- 新增 `src/codex-queue.ts`：queue 载体 + 活性探测。
- 投递阶梯改为 **queue → Desktop IPC → cmux**。unknown-outcome 在任一层都立即停止，绝不重放（铁律 5）。
- **活性必须自己判**：`queue` 是往 thread store 写待处理输入，**不是投递**——目标已退出时照样 `exit=0` 并打印 `Queued message …`。判据取 rollout 文件的 fd 持有者（`lsof`），查不到就一个字都不发（fail closed），欠账留 inbox。
- `ocs who` 可达性改为「有活进程持有 rollout」**或**「被 renderer 认领」，并标注载体（`[queue pid N]` / `[desktop]`）。本机实测可达 codex 任务 **1 → 5**。
- `doctor` 增加 `codex queue` 可用性一行；Desktop IPC 不可用不再等于 codex 不可达。
- 顺带修：批量 lsof 要用 realpath 比对（macOS `/var` → `/private/var`）；lsof 查找不能依赖调用方传进来的 PATH。

## 验证

实测 codex-cli v0.153.4，**端到端真跑**（不只是单测）：

```
ocs dm codex-01a079c8 "OCS-E2E: reply with exactly MANGO"
→ wake(codex): queued → task 01a079c8-… via `codex queue` (live pid 16889) — queued, not confirmed read
```

tmux 里的纯终端 codex TUI 收到唤醒 → 自己读 skill → `ocs send` 回复 → `MANGO` 回到频道。**全程没有 cmux、没有 Desktop**，也不需要 `codex app-server daemon start`（那条另外要求官方 standalone 安装）。

测试 168 全绿：新增 8 条 codex-queue 用例，外加 1 条回归——未被 renderer 认领但活着的终端 TUI 必须出现在 `who` 里，即群里报的那个 bug。

## 载体审计（不在本 PR 改动范围，结论记入 DESIGN.md）

另外两条腿**都不是绕路**，各自已在官方表面上：

- **Claude**：cc-socks 收件箱就是 Claude Code 自己的跨会话通道（原生 "Message from X" + `crossSessionInbound` 权限闸），`claude` CLI 没有等价的发送子命令。
- **Pi**：走 Pi 官方扩展 API，`pi` CLI 根本没有跨会话命令。

两条待改进（未实现）：Claude 侧的「ok ≠ 送达」可靠订阅 `peer_message_status` 回执收敛；`claude agents --json` 能列出**后台会话**（`kind: "background"`），那是 ocs 今天完全没寻址的一类本机 agent，但 `claude` 也没给后台会话提供发送口——发现有，投递无。

## 文档

CLAUDE.md 铁律 10 重写、DESIGN.md 传输层与架构图、SKILL.md。

https://claude.ai/code/session_01LnaJjCP5xmpqmHnRQLQpjZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex message delivery through the official `codex queue` command.
  * `ocs who` now shows reachable Codex tasks, including terminal sessions and Desktop sessions, with their delivery method.
  * `ocs doctor` now reports whether Codex queue delivery is available.
  * Codex tasks can receive messages without requiring an open Desktop renderer.

* **Bug Fixes**
  * Messages remain available in the task inbox when delivery cannot be confirmed, preventing silent loss.
  * Delivery now avoids targeting inactive Codex sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->